### PR TITLE
Delimit `make list` output with linebreaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,4 +325,4 @@ destroy: network-remove $(foreach p,$(REACTION_PROJECTS),destroy-$(p))
 ###############################################################################
 .PHONY: list
 list:
-	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | xargs
+	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | xargs -n 1


### PR DESCRIPTION
Resolves: A sea of text
Impact: **minor**  
Type: **feature**

## Issue
`make list` is a useful command to see the list of targets generated by the meta templating. Before this change the targets were space delimited. I'd been piping to `| xargs -n 1` manually. This automatically outputs them with linebreaks is easier to grok and work with on the command line. 

For example, to see targets directly related to hydra:

```
make list | grep hydra

# build-reaction-hydra
# clean-reaction-hydra
# destroy-reaction-hydra
# init-reaction-hydra
# init-with-system-reaction-hydra
# ...
```

## Testing
1. Run `make list`
2. Behold the power.
