### PR TITLE
add checkout templated command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,34 @@ Example:
 make init-reaction-next-starterkit
 ```
 
+**Bootstrapping with Particular Git Branches**
+
+The normal bootstrapping process will give you the latest released versions of the platform subprojects and is the recommended configuration for regular development. However, if you know you require a particular previous release or alternative git branch, you can take the following steps to bring up the platform with the particular versions you need. These steps are an alternative to the standard bootstrapping approach, you should do one or the other, not both.
+
+From the project directory run
+
+```sh
+make clone
+```
+
+Within the necessary subproject directory or directories run the `git checkout <your-release-tag-or-branch>` commands you need to get the specific subproject versions you need checked out.
+
+Example:
+
+```sh
+cd reaction-next-starterkit
+git checkout develop
+```
+
+Then run the following
+
+```sh
+cd .. # cd into reaction-platform
+make
+```
+
+This will proceed with the bootstrapping process using the versions you have explicitly checked out
+
 ## Networked Services
 
 User-defined Docker networks are used to connect the Reaction services that run


### PR DESCRIPTION
Resolves #9  
Impact: **minor**  
Type: **feature**

## Issue

Main issue is current code always uses the default branch of each repo (some use master, some use develop) and many times users/developers will want to checkout a particular release which consists of particular tags of each subproject, or more generally will want to have a different branch checkout out than the default.

Related issue is we probably need some mechanism to coordinate versions of the subprojects that are tested together and known compatible/supported. This commit introduces a basic Makefile variable CSV structure to do that.

## Solution

I followed the existing Makefile metaprogramming patterns to generate a `make checkout` and `make checkout-subproject*` templates.

This code has some pretty advanced Makefile metaprogramming that may pretzelize your brain and the shell escaping that is necessary also probably deserves substantial apology. Sorry.


## Breaking changes
None

## Testing
I tested this with both branches and tags and it works for
1. Fresh clone
1. Reclone of existing

This is some very basic scripting here and it is pretty easy to get your filesystem into a broken state that the scripting will not handle properly.