### PR TITLE
feat: verify github ssh access but not ssh key details

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,13 @@ init: $(foreach p,$(REACTION_PROJECTS),init-$(p)) post-system-start
 ###############################################################################
 ### Targets to verify Github is configured correctly.
 ###############################################################################
-ssh-public-key: ~/.ssh/id_rsa.pub
-	@echo "SSH public key verified at ~/.ssh/id_rsa.pub"
+ssh-public-key:
+	@if [ -z $$(find "${HOME}/.ssh" -name 'id_*.pub') ]; then \
+		echo "No ssh public key found. Generating one via ssh-keygen."; \
+		ssh-keygen; \
+	else \
+		echo "ssh public key verified"; \
+	fi
 
 ~/.ssh/id_rsa.pub:
 	@ssh-keygen

--- a/Makefile
+++ b/Makefile
@@ -61,30 +61,15 @@ $(foreach p,$(REACTION_PROJECTS),$(eval $(call init-with-system-template,$(p))))
 .PHONY: init
 init: $(foreach p,$(REACTION_PROJECTS),init-$(p)) post-system-start
 
-
 ###############################################################################
 ### Targets to verify Github is configured correctly.
 ###############################################################################
-ssh-public-key:
-	@if [ -z $$(find "${HOME}/.ssh" -name 'id_*.pub') ]; then \
-		echo "No ssh public key found. Generating one via ssh-keygen."; \
-		ssh-keygen; \
-	else \
-		echo "ssh public key verified"; \
-	fi
-
-~/.ssh/id_rsa.pub:
-	@ssh-keygen
-
-github-configured: dependencies ssh-public-key
+github-configured: dependencies
 	@(ssh -T git@github.com 2>&1 \
 	  | grep "successfully authenticated" >/dev/null \
 	  && echo "Github login verified.") \
-	|| (echo "You need to add your public key to Github" \
-	&& echo "Github settings URL: https://github.com/settings/keys" \
-	&& echo "== Start copy at next line ===" \
-	&& cat ~/.ssh/id_rsa.pub \
-	&& echo "== End copy at above line ===" \
+	|| (echo "You need to configure an ssh key with access to github" \
+	&& echo "See https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/ for instructions" \
 	&& exit 101)
 
 


### PR DESCRIPTION
I use ed25519 ssh keys and the existing target only acknowledges rsa.

 
Impact: **minor**  
Type: **bugfix**

## Solution

Use find and a glob to accept anything `~/.ssh/id_*.pub`