### PR TITLE
Fix syntax of dependency variable definition

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -13,10 +13,10 @@
 # List of tools that must be installed.
 # A simple check to determine the tool is available. No version check, etc.
 define REQUIRED_SOFTWARE =
-docker
-docker-compose
-git
-node
+docker \
+docker-compose \
+git \
+node \
 yarn
 endef
 


### PR DESCRIPTION
Resolves #26  
Impact: **major**  
Type: **bugfix**

## Issue
Missing line continuation backslashes in the REQUIRED_SOFTWARE variable.

## Solution
Add backslashes where needed.

## Testing

`make dependencies` now works without error