### PR TITLE
Add streams.reaction.localhost network

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -35,7 +35,8 @@ endef
 # List of user defined networks that should be created.
 define DOCKER_NETWORKS =
 auth.reaction.localhost \
-api.reaction.localhost
+api.reaction.localhost \
+streams.reaction.localhost
 endef
 
 HOOK_DIR=.reaction/project-hooks


### PR DESCRIPTION

Impact: **minor**  
Type: **feature**

## Issue
We will be using a network `streams.reaction.localhost` for streaming infrastructure used by some new feature development. Add this network to the list so reaction-platform can create it during setup.