### PR TITLE
fix: Avoid old make version multiline var syntax

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -12,7 +12,7 @@
 
 # List of tools that must be installed.
 # A simple check to determine the tool is available. No version check, etc.
-define REQUIRED_SOFTWARE =
+define REQUIRED_SOFTWARE
 docker \
 docker-compose \
 git \
@@ -33,7 +33,7 @@ git@github.com:/reactioncommerce/reaction-next-starterkit.git,reaction-next-star
 endef
 
 # List of user defined networks that should be created.
-define DOCKER_NETWORKS =
+define DOCKER_NETWORKS
 auth.reaction.localhost \
 api.reaction.localhost \
 streams.reaction.localhost


### PR DESCRIPTION
Resolves #32 
Impact: **minor**  
Type: **bugfix**

## Issue

The issue describes certain make targets failing, with a theory that a difference in syntax support between make 3.81 and later being the root cause.

## Solution

Don't use `=` when defining multiline variables.

## Breaking changes

N/A

## Testing

* Basic manual smoke testing on linux
* Basic manual smoke testing on a mac with make v3.81

```
make network-create
27d78333a74304ceb1c93ef6978d7677a96263c383e649a53027a1f72822084d
d714d825397e9b2d5f341b0d44341acc92895f221644a2b02989ecfba3a88330
2ec11658c2a73df8df5c9ea3f4a619ff048a7487ed34978e3211de686a63b7a0
```