### PR TITLE
fix: checkout git ref during init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ all: init
 ### Initializes a project. Does not do common tasks shared between projects.
 ###############################################################################
 define init-template
-init-$(1): $(1) network-create prebuild-$(1) build-$(1) post-build-$(1) start-$(1) post-project-start-$(1)
+init-$(1): $(1) checkout-$(1) network-create prebuild-$(1) build-$(1) post-build-$(1) start-$(1) post-project-start-$(1)
 endef
 $(foreach p,$(SUBPROJECTS),$(eval $(call init-template,$(p))))
 


### PR DESCRIPTION
Resolves #37
Impact: **critical**  
Type: **bugfix**

## Issue
Running `make` without any additional arguments on a fresh clone of `reaction-platform` is equivalent to running `make init`

The `init` template looks like this:

```sh
define init-template
init-$(1): $(1) network-create prebuild-$(1) build-$(1) post-build-$(1) start-$(1) post-project-start-$(1)
endef
$(foreach p,$(SUBPROJECTS),$(eval $(call init-template,$(p))))
```

the `clone` template looks like this
```
define git-clone-template
$(2):
	git clone "$(1)" "$(2)"
endef
```
 
My understanding is that the `$(1)` variable in the init template ends up running clone defined as `$(2)` in the clone template.

The `init` template does _not_ run the `checkout` template. 

Until recently, we used the `master` branch as default for all projects which are cloned by `reaction-platform`. The `master` branch is also listed as the default ref in the `config.mk` file. I believe this contributed to us failing to realize that the ref listed in `config.mk` was not being respected when `make` was run.


## Solution
I've added `checkout-$(1)` between `$(1)` and `network-create` to the `init-template` 

## Other notes
This may lead to unexpected behavior when running `make` / `make init` on a project that's been setup previously running on a non-default or config branch. I'd expect that `init` is not likely to be run commonly on an existing project, but realize that developers use `make` to refresh their docker environment sometimes when things aren't working as anticipated. 

We could possibly mitigate this by checking out the reference as part of the `clone` template by passing `-b $(git-branch-or-tag)` and leaving `checkout` out of the init process. This would permit checking out of tags or branches but not commit refs I believe.

## Breaking changes
n/a


## Testing
1. Confirm that running `make` and `make init` on a default setup performs as expected
2. Confirm that setting a custom `config.mk` file works as expected
3. Confirm that running `make checkout` works as expected.
