### PR TITLE
fix: missing semicolon and correct checkout directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ define git-clone-template
 $(2):
 	if [ ! -d "$(2)" ] ; then \
 	  git clone "$(1)" "$(2)"; \
-	  cd $(1) && git checkout "$(3)" \
+	  cd $(2) && git checkout "$(3)"; \
 	fi
 endef
 $(foreach rr,$(SUBPROJECT_REPOS),$(eval $(call git-clone-template,$(shell echo $(rr) | cut -d , -f 1),$(shell echo $(rr) | cut -d , -f 2),$(shell echo $(rr) | cut -d , -f 3))))


### PR DESCRIPTION
Resolves #43  
Impact: **breaking**  
Type: **bugfix**

## Issue
There was a missing semicolon in the clone target `$(2)` and when we rewrote the clone target to include checkout, the directory to `cd` into was typoed.

## Solution
Adds missing semicolon to prevent unexpected end of file.
Changes checkout directory from `$(1)` which is the git url to `$(2)` which is the project/repo name.


## Breaking changes
n/a

## Testing
1. Run `make` on a fresh project. Test with default branches and custom using `config.local.mk`