### PR TITLE
v2.0.0-rc.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
 # v2.0.0-rc.10
 This is our second official release candidate for this project. This project should be considered pre-release until we've released the final 2.0.0 version.
+
+# v2.0.0-rc.9
+This is our first official release candidate for this project - we're going to be synchronizing releases across the differents parts of the Reaction Commerce ecosystem, so that's why we're starting with rc.9. This project should be considered pre-release until we've released the final 2.0.0 version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
-# v2.0.0-rc.9
-This is our first official release candidate for this project - we're going to be synchronizing releases across the differents parts of the Reaction Commerce ecosystem, so that's why we're starting with rc.9. This project should be considered pre-release until we've released the final 2.0.0 version.
+# v2.0.0-rc.10
+This is our second official release candidate for this project. This project should be considered pre-release until we've released the final 2.0.0 version.

--- a/config.mk
+++ b/config.mk
@@ -27,9 +27,9 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
-git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v2.0.0-rc.9 \
-git@github.com:/reactioncommerce/reaction.git,reaction,v2.0.0-rc.9 \
-git@github.com:/reactioncommerce/reaction-next-starterkit.git,reaction-next-starterkit,v2.0.0-rc.9
+git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,release-v2.0.0-rc.10 \
+git@github.com:/reactioncommerce/reaction.git,reaction,release-v2.0.0-rc.10 \
+git@github.com:/reactioncommerce/reaction-next-starterkit.git,reaction-next-starterkit,release-v2.0.0-rc.10
 endef
 
 # List of user defined networks that should be created.

--- a/config.mk
+++ b/config.mk
@@ -27,9 +27,9 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
-git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,release-v2.0.0-rc.10 \
-git@github.com:/reactioncommerce/reaction.git,reaction,release-v2.0.0-rc.10 \
-git@github.com:/reactioncommerce/reaction-next-starterkit.git,reaction-next-starterkit,release-v2.0.0-rc.10
+git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v2.0.0-rc.10 \
+git@github.com:/reactioncommerce/reaction.git,reaction,v2.0.0-rc.10 \
+git@github.com:/reactioncommerce/reaction-next-starterkit.git,reaction-next-starterkit,v2.0.0-rc.10
 endef
 
 # List of user defined networks that should be created.


### PR DESCRIPTION
# v2.0.0-rc.10

This is our second official release candidate for this project.

## Testing Notes
The `config.mk` file to use the release tags coordinated across the reaction platform. 
  - [reaction-next-starterkit](https://github.com/reactioncommerce/reaction-next-starterkit/pull/512)
  - [reaction](https://github.com/reactioncommerce/reaction/pull/5016)
  - [reaction-hydra](https://github.com/reactioncommerce/reaction-hydra/pull/12)


The QA for the release of this version of `reaction-platform` should involve testing that the projects are compatible and work together. 

Running this release-candidate branch of `reaction-platform` should also set up the associated release branch for each of the projects in the platform. These are the versions that should be tested - that they are performing as expected, and that they are compatible with each other.