### PR TITLE
chore: updated all reference of starterkit to example-storefront.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ make
 This process may take some time. Behind the scenes `make` is
 
 * checking that dependencies are present
-* cloning the sub projects from GitHub: [`reaction`][10], [`reaction-hydra`][12], and [`reaction-next-starterkit`][13]
+* cloning the sub projects from GitHub: [`reaction`][10], [`reaction-hydra`][12], and the [`example-storefront`][13]
 * downloading Docker images
 * building custom, project Docker images
 * starting services
@@ -66,7 +66,7 @@ make init-<project-name>
 Example:
 
 ```sh
-make init-reaction-next-starterkit
+make init-example-storefront
 ```
 
 **Bootstrapping with Particular Git Branches**
@@ -84,7 +84,7 @@ Within the necessary subproject directory or directories run the `git checkout <
 Example:
 
 ```sh
-cd reaction-next-starterkit
+cd example-storefront
 git checkout develop
 ```
 
@@ -130,7 +130,7 @@ These services will be running when the initial `make` command is complete:
 | ------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | [OAuth2 Server (Hydra)][12] (http://localhost:4444)    | [ORY Hydra][11] OAuth2 token server.                                                         |
 | [Reaction Meteor][10] (http://localhost:3000)          | The Reaction Meteor application, which includes the server API and the Meteor UI client.                                                             |
-| [Reaction NextJS Storefront][13] (http://localhost:4000) | A starter Reaction storefront UI built with [Next.JS](https://github.com/zeit/next.js/).                          |
+| [Example Storefront][13] (http://localhost:4000) | An example Reaction storefront UI built with [Next.JS](https://github.com/zeit/next.js/).                          |
 
 ### GraphQL Interface
 After running `make start`, you should be able to explore the GraphQL API at http://localhost:3000/graphiql. See [GraphiQL docs](https://github.com/graphql/graphiql)
@@ -148,7 +148,7 @@ Run these commands from the `reaction-platform` project root directory.
 | `make start`               | Starts all containers.                                                                |
 | `make rm`                  | Removes all containers. Volumes are not removed.                                      |
 | `make clean`               | Removes all containers, networks, and volumes. Any volume data will be lost.          |
-| `make init-<project-name>` | Example: `make init-reaction-next-starterkit`. Does clone/setup for a single project. |
+| `make init-<project-name>` | Example: `make init-example-storefront`. Does clone/setup for a single project. |
 
 ## Documentation
 
@@ -158,7 +158,7 @@ You may refer to each sub-project's README for additonal operation details.
 | ------------ | ---------------------------------------------------------------------------- |
 | `reaction`       | [Reaction Documentation][14]             |
 | `reaction-hydra`  | [`reaction-hydra`][12], [`ory/hydra`][11]                                                        |
-| `reaction-next-starterkit` | [Starterkit docs][15]
+| `example-storefront` | [Example Storefront docs][15]
 
 For tips on developing on Docker, read our [Docker docs](https://docs.reactioncommerce.com/docs/installation-docker-development).
 
@@ -179,6 +179,6 @@ Copyright © [GNU General Public License v3.0](./LICENSE.md)
 [10]: https://github.com/reactioncommerce/reaction "Reaction"
 [11]: https://github.com/ory/hydra "ORY Hydra"
 [12]: https://github.com/reactioncommerce/reaction-hydra "Reaction Hydra"
-[13]: https://github.com/reactioncommerce/reaction-next-starterkit "Reaction Next.js Starterkit"
+[13]: https://github.com/reactioncommerce/example-storefront "Example Storefront"
 [14]: https://docs.reactioncommerce.com "Reaction Documentation"
-[15]: https://github.com/reactioncommerce/reaction-next-starterkit/tree/master/docs "Starterkit docs"
+[15]: https://github.com/reactioncommerce/example-storefront/tree/master/docs "Example Storefront docs"

--- a/config.mk
+++ b/config.mk
@@ -29,7 +29,7 @@ endef
 define SUBPROJECT_REPOS
 git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v2.0.0-rc.11 \
 git@github.com:/reactioncommerce/reaction.git,reaction,v2.0.0-rc.11 \
-git@github.com:/reactioncommerce/reaction-next-starterkit.git,reaction-next-starterkit,v2.0.0-rc.11
+git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v2.0.0-rc.11
 endef
 
 # List of user defined networks that should be created.


### PR DESCRIPTION
Impact: **breaking|critical**  
Type: **chore**

## Issue
We want to rename our storefront from "reaction-next-starterkit" to "example-storefront", to do this we need to update all references to that project/repo before we can officially change the name. 

## Solution
Updated the git repo name in the `config.mk` file, updated all refs/links in the README

## Testing
N/A