### PR TITLE
release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.1.0
+This is a minor versioning release coordinated with [Reaction](https://github.com/reactioncommerce/reaction), our [Example Storefront](https://github.com/reactioncommerce/example-storefront) and [reaction-hydra](https://github.com/reactioncommerce/reaction-hydra).
+
 # v2.0.0
 This is our first release of Reaction Platform.
 

--- a/config.mk
+++ b/config.mk
@@ -27,9 +27,9 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
-git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v2.0.0 \
-git@github.com:/reactioncommerce/reaction.git,reaction,v2.0.0 \
-git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v2.0.0
+git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v2.1.0 \
+git@github.com:/reactioncommerce/reaction.git,reaction,v2.1.0 \
+git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v2.1.0
 endef
 
 # List of user defined networks that should be created.


### PR DESCRIPTION
- https://github.com/reactioncommerce/reaction/pull/5409
- https://github.com/reactioncommerce/reaction-hydra/pull/22
- https://github.com/reactioncommerce/example-storefront/pull/557/

# v2.1.0
This is a minor versioning release coordinated with [Reaction](https://github.com/reactioncommerce/reaction), our [Example Storefront](https://github.com/reactioncommerce/example-storefront) and [reaction-hydra](https://github.com/reactioncommerce/reaction-hydra).