### PR TITLE
chore: bump to version 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.7.0
+This is minor version update coordinated with [Reaction](https://github.com/reactioncommerce/reaction), our [Example Storefront](https://github.com/reactioncommerce/example-storefront) and [reaction-hydra](https://github.com/reactioncommerce/reaction-hydra).
+
 # v2.6.0
 This is minor version update coordinated with [Reaction](https://github.com/reactioncommerce/reaction), our [Example Storefront](https://github.com/reactioncommerce/example-storefront) and [reaction-hydra](https://github.com/reactioncommerce/reaction-hydra).
 

--- a/config.mk
+++ b/config.mk
@@ -27,9 +27,9 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
-git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v2.6.0 \
-git@github.com:/reactioncommerce/reaction.git,reaction,v2.6.0 \
-git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v2.6.0
+git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v2.7.0 \
+git@github.com:/reactioncommerce/reaction.git,reaction,v2.7.0 \
+git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v2.7.0
 endef
 
 # List of user defined networks that should be created.


### PR DESCRIPTION
# v2.7.0
This is minor version update coordinated with [Reaction](https://github.com/reactioncommerce/reaction), our [Example Storefront](https://github.com/reactioncommerce/example-storefront) and [reaction-hydra](https://github.com/reactioncommerce/reaction-hydra).