### PR TITLE
chore: release v3.0.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v3.0.0-alpha
+
+This is a major update to keep this project in sync with
+[reaction v3.0.0-alpha](https://github.com/reactioncommerce/reaction),
+[example-storefront v3.0.0-alpha](https://github.com/reactioncommerce/example-storefront),
+and [reaction-platform v3.0.0-alpha](https://github.com/reactioncommerce/reaction-platform).
+
 # v2.9.0
 This is minor version update coordinated with [Reaction](https://github.com/reactioncommerce/reaction), our [Example Storefront](https://github.com/reactioncommerce/example-storefront) and [reaction-hydra](https://github.com/reactioncommerce/reaction-hydra).
 

--- a/config.mk
+++ b/config.mk
@@ -27,9 +27,9 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
-git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v2.9.0 \
-git@github.com:/reactioncommerce/reaction.git,reaction,v2.9.0 \
-git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v2.9.0
+git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0-alpha \
+git@github.com:/reactioncommerce/reaction.git,reaction,v3.0.0-alpha \
+git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0-alpha
 endef
 
 # List of user defined networks that should be created.

--- a/config.mk
+++ b/config.mk
@@ -30,7 +30,7 @@ define SUBPROJECT_REPOS
 git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0-alpha \
 git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-alpha \
 git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0-alpha \
-git@github.com:/reactioncommerce/reaction-indentity.git,reaction-indentity,v3.0.0-alpha \
+git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0-alpha \
 git@github.com:/reactioncommerce/reaction.git,reaction,v3.0.0-alpha
 endef
 

--- a/config.mk
+++ b/config.mk
@@ -27,9 +27,11 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
+git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0-alpha \
+git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-alpha \
 git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0-alpha \
-git@github.com:/reactioncommerce/reaction.git,reaction,v3.0.0-alpha \
-git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0-alpha
+git@github.com:/reactioncommerce/reaction-indentity.git,reaction-indentity,v3.0.0-alpha \
+git@github.com:/reactioncommerce/reaction.git,reaction,v3.0.0-alpha
 endef
 
 # List of user defined networks that should be created.

--- a/config.mk
+++ b/config.mk
@@ -36,6 +36,7 @@ endef
 
 # List of user defined networks that should be created.
 define DOCKER_NETWORKS
+reaction.localhost \
 auth.reaction.localhost \
 api.reaction.localhost \
 streams.reaction.localhost


### PR DESCRIPTION
# v3.0.0-alpha

This is a major update to keep this project in sync with
[reaction v3.0.0-alpha](https://github.com/reactioncommerce/reaction),
[example-storefront v3.0.0-alpha](https://github.com/reactioncommerce/example-storefront),
and [reaction-platform v3.0.0-alpha](https://github.com/reactioncommerce/reaction-platform).
