### PR TITLE
Add dc pull, and update Readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ post-build: $(foreach p,$(SUBPROJECTS),post-build-$(p))
 define start-template
 start-$(1):
 	@cd $(1) \
-	  && docker-compose pull
+	  && docker-compose pull \
 	  && docker-compose up -d
 endef
 $(foreach p,$(SUBPROJECTS),$(eval $(call start-template,$(p))))

--- a/Makefile
+++ b/Makefile
@@ -209,10 +209,15 @@ post-build: $(foreach p,$(SUBPROJECTS),post-build-$(p))
 ###############################################################################
 ### Start
 ### Starts services with `docker-compose up -d`
+###
+### Pull the specified image tags every time. Tags are constantly being updated
+### to point to different image IDs, and there is less to debug if we can be
+### reasonably sure that you're always starting the latest image with that tag.
 ###############################################################################
 define start-template
 start-$(1):
 	@cd $(1) \
+	  && docker-compose pull
 	  && docker-compose up -d
 endef
 $(foreach p,$(SUBPROJECTS),$(eval $(call start-template,$(p))))

--- a/README.md
+++ b/README.md
@@ -11,20 +11,12 @@ supporting services in a local development environment.
 * Docker based development environment.
 * Launched and configured with a single CLI command.
 
-### Project Structure
-
-Reaction Platform is built with a microservices architecture. This project
-provides the tooling to easily orchestrate the services in a local development
-environment.
-
-Platform services will be cloned as child directories within this project.
-
 ## Prerequisites
 
 * [GNU Make](https://www.gnu.org/software/make/)
-  * macos and linux users will have a suitable version bundled with the OS
+  * MacOS and linux users will have a suitable version bundled with the OS
 * Bourne Shell and POSIX tools (sh, grep, sed, awk, etc)
-  * macos and linux users will have a suitable version bundled with the OS
+  * MacOS and linux users will have a suitable version bundled with the OS
 * [Git][5]
 * [Docker][0] | [Docker for Mac][1] | [Docker for Windows][2]
 * [Node.js][3]
@@ -33,29 +25,30 @@ Platform services will be cloned as child directories within this project.
 
 ## Getting started
 
-First, clone this repository.
+Clone this repository, and then run `make` in the `reaction-platform` directory. If all goes well, it will take some time to download and start all of the components, but when it's done you'll have the entire Reaction application running on your computer through Docker. Individual services are cloned as child directories within this project.
 
 ```sh
 git clone git@github.com:reactioncommerce/reaction-platform.git
-
 cd reaction-platform
-```
-
-#### Bootstrapping
-
-From within the project directory run:
-
-```sh
 make
 ```
 
-This process may take some time. Behind the scenes `make` is
+Behind the scenes `make` is
 
 * checking that dependencies are present
-* cloning the sub projects from GitHub: [`reaction`][10], [`reaction-hydra`][12], and the [`example-storefront`][13]
+* cloning sub-projects from GitHub
 * downloading Docker images
-* building custom, project Docker images
 * starting services
+
+These services will be running when the initial `make` command is complete:
+
+| Service                                             | Description                                                                                                                                                                                         |
+|-----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [OAuth2 Server (Hydra)][12] (http://localhost:4444) | [ORY Hydra][11] OAuth2 token server.                                                                                                                                                                |
+| [Reaction Identity][16] (http://localhost:4100)     | The OAuth2-compatible user interface for Reaction identity, such as login and registration.                                                                                                         |
+| [Reaction API][10] (http://localhost:3000)          | The Reaction API, which includes [a GraphQL endpoint](http://localhost:3000/graphql-beta). See [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/features/graphql-playground/). |
+| [Reaction Admin][17] (http://localhost:4080)        | A user interface for administrators and shop managers to configure shops, manage products, and process orders.                                                                                      |
+| [Example Storefront][13] (http://localhost:4000)    | An example Reaction storefront UI built with [Next.JS](https://github.com/zeit/next.js/).                                                                                                           |
 
 If the `make` command fails at some point, you can run or rerun it for specific services with:
 
@@ -69,33 +62,56 @@ Example:
 make init-example-storefront
 ```
 
-**Bootstrapping with Particular Git Branches**
+## Project Commands
 
-The normal bootstrapping process will give you the latest released versions of the platform subprojects and is the recommended configuration for regular development. However, if you know you require a particular previous release or alternative git branch, you can take the following steps to bring up the platform with the particular versions you need. These steps are an alternative to the standard bootstrapping approach, you should do one or the other, not both.
+These are the available `make` commands in the `reaction-platform` root directory.
 
-From the project directory run
+| Command                                                 | Description                                                                                                                                     |
+|---------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `make`                                                  | Bootstraps the entire Reaction development environment in Docker.                                                                               |
+| `make init-<project-name>`                              | Example: `make init-example-storefront`. Does clone/setup for a single project.                                                                 |
+| `make stop`                                             | Stops all containers.                                                                                                                           |
+| `make stop-<project-name>`                              | Example: `make stop-example-storefront`. Stops all containers for a single project.                                                             |
+| `make start`                                            | Starts all containers.                                                                                                                          |
+| `make start-<project-name>`                             | Example: `make start-example-storefront`. Starts all containers for a single project.                                                           |
+| `make rm`                                               | Removes all containers. Volumes are not removed.                                                                                                |
+| `make rm-<project-name>`                                | Example: `make rm-example-storefront`. Removes all containers for a single project. Volumes are not removed.                                    |
+| `make checkout-<project-name> <git-tag-or-branch-name>` | Example: `make checkout-example-storefront release-v3.0.0`. Does `git checkout` for a sub-project. See "Running Particular Git Branches" below. |
+| `make clean`                                            | Removes all containers, networks, and volumes. Any volume data will be lost.                                                                    |
+| `make clean-<project-name>`                             | Example: `make clean-example-storefront`. Removes all containers, networks, and volumes for a single project. Any volume data will be lost.     |
 
-```sh
-make clone
-```
+## Running Particular Git Branches
 
-Within the necessary subproject directory or directories run the `git checkout <your-release-tag-or-branch>` commands you need to get the specific subproject versions you need checked out.
+After you've done the "Getting Started" steps and have the latest Reaction system running, you may need to switch to and run a certain branch/tag in one or more of the sub-projects.
+
+To check out and run a certain branch or tag for a project, stop the project, run `make checkout-<project-name> <git-tag-or-branch-name>`, and then init the project again.
 
 Example:
 
 ```sh
-cd example-storefront
-git checkout develop
+make stop-example-storefront
+make checkout-example-storefront release-v3.0.0
+make init-example-storefront
 ```
 
-Then run the following
+If you're getting unexpected results, `cd` into the sub-project directory and do a `git pull` to verify you're on the latest commit from that branch. If you're changing code files, see the "Running From Code For Development" section below.
+
+### Running From Code For Development
+
+To ensure they start quickly, all Reaction projects are configured (in their `docker-compose.yml` file) to run from the latest published Docker image. This means that if you change code files, you will not see your changes reflected in the running application. To switch over to development mode for a single project:
 
 ```sh
-cd .. # cd into reaction-platform
-make
+# Stop the project
+make stop-<project-name>
+
+# Create a Docker Compose override file for the project
+ln -s ./<project-name>/docker-compose.dev.yml ./<project-name>/docker-compose.override.yml
+
+# Start the project
+make start-<project-name>
 ```
 
-This will proceed with the bootstrapping process using the versions you have explicitly checked out
+If you run into trouble with the above steps, `make clean-<project-name>` and then `make init-<project-name>`.
 
 ## Networked Services
 
@@ -117,48 +133,22 @@ conflict with a real TLD.
 
 ### Network List
 
-| Network                    | Description                                    |
-| -------------------------- | ---------------------------------------------- |
-| api.reaction.localhost     | GraphQL and API traffic between services.      |
-| auth.reaction.localhost    | Authentication and authorization services.     |
-
-## Services
-
-These services will be running when the initial `make` command is complete:
-
-| Service                                           | Description                                                                                  |
-| ------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| [OAuth2 Server (Hydra)][12] (http://localhost:4444)    | [ORY Hydra][11] OAuth2 token server.                                                         |
-| [Reaction Meteor][10] (http://localhost:3000)          | The Reaction Meteor application, which includes the server API and the Meteor UI client.                                                             |
-| [Example Storefront][13] (http://localhost:4000) | An example Reaction storefront UI built with [Next.JS](https://github.com/zeit/next.js/).                          |
-
-### GraphQL Interface
-After running `make start`, you should be able to explore the GraphQL API at http://localhost:3000/graphql-beta. See [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/features/graphql-playground/).
-
-## Project Commands
-
-These commands are used to control the system as a whole.
-
-Run these commands from the `reaction-platform` project root directory.
-
-| Command                    | Description                                                                           |
-| -------------------------- | ------------------------------------------------------------------------------------- |
-| `make`                     | Boostraps the entire Reaction development environment in Docker.                      |
-| `make stop`                | Stops all containers.                                                                 |
-| `make start`               | Starts all containers.                                                                |
-| `make rm`                  | Removes all containers. Volumes are not removed.                                      |
-| `make clean`               | Removes all containers, networks, and volumes. Any volume data will be lost.          |
-| `make init-<project-name>` | Example: `make init-example-storefront`. Does clone/setup for a single project. |
+| Network                    | Description                                                         |
+|----------------------------|---------------------------------------------------------------------|
+| api.reaction.localhost     | GraphQL and API traffic between services                            |
+| auth.reaction.localhost    | Authentication and authorization services                           |
+| streams.reaction.localhost | Streams and databases                                               |
+| reaction.localhost         | General purpose. We are moving toward having only this one network. |
 
 ## Documentation
 
-You may refer to each sub-project's README for additonal operation details.
+You may refer to each sub-project's README for additional operation details.
 
-| Sub-project      | Documentation                                                                  |
-| ------------ | ---------------------------------------------------------------------------- |
-| `reaction`       | [Reaction Documentation][14]             |
-| `reaction-hydra`  | [`reaction-hydra`][12], [`ory/hydra`][11]                                                        |
-| `example-storefront` | [Example Storefront docs][15]
+| Sub-project          | Documentation                             |
+|----------------------|-------------------------------------------|
+| `reaction`           | [Reaction Documentation][14]              |
+| `reaction-hydra`     | [`reaction-hydra`][12], [`ory/hydra`][11] |
+| `example-storefront` | [Example Storefront docs][15]             |
 
 For tips on developing on Docker, read our [Docker docs](https://docs.reactioncommerce.com/docs/installation-docker-development).
 
@@ -176,9 +166,11 @@ Copyright © [GNU General Public License v3.0](./LICENSE.md)
 [7]: https://github.com/settings/keys "GitHub SSH Keys"
 [8]: https://github.com/reactioncommerce/reaction-platform "Reaction Platform"
 [9]: https://github.com/graphcool/graphql-playground "GraphQL Playground"
-[10]: https://github.com/reactioncommerce/reaction "Reaction"
+[10]: https://github.com/reactioncommerce/reaction "Reaction API"
 [11]: https://github.com/ory/hydra "ORY Hydra"
 [12]: https://github.com/reactioncommerce/reaction-hydra "Reaction Hydra"
 [13]: https://github.com/reactioncommerce/example-storefront "Example Storefront"
 [14]: https://docs.reactioncommerce.com "Reaction Documentation"
 [15]: https://github.com/reactioncommerce/example-storefront/tree/master/docs "Example Storefront docs"
+[16]: https://github.com/reactioncommerce/reaction-identity "Reaction Identity"
+[17]: https://github.com/reactioncommerce/reaction-admin "Reaction Admin"


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Changes
- `make start` now does `docker-compose pull` before `docker-compose up -d`. This should prevent some of the confusion we've seen when you pull latest git commit but are seeing old behavior because latest Docker tag isn't also pulled.
- Also updated README for 3.0.0 changes

## Testing
Verify `make start` and `make start-<project-name>` commands continue to work and pull the latest images specified in the `docker-compose.yml` file.