### PR TITLE
fix: ignore dc pull errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,12 +213,15 @@ post-build: $(foreach p,$(SUBPROJECTS),post-build-$(p))
 ### Pull the specified image tags every time. Tags are constantly being updated
 ### to point to different image IDs, and there is less to debug if we can be
 ### reasonably sure that you're always starting the latest image with that tag.
+###
+### We are purposely running dc up even if dc pull fails. Our Meteor project DC
+### config uses `image` as a desired image tag for `build` when in dev mode. But
+### `dc pull` seems to have a bug where it doesn't treat it this way and tries
+### to pull it.
 ###############################################################################
 define start-template
 start-$(1):
-	@cd $(1) \
-	  && docker-compose pull \
-	  && docker-compose up -d
+	@cd $(1) && docker-compose pull; docker-compose up -d
 endef
 $(foreach p,$(SUBPROJECTS),$(eval $(call start-template,$(p))))
 


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
Same version bugfix

#90 made `make start` do `docker-compose pull && docker-compose up -d`. Unfortunately, when the Reaction Admin or Reaction Identity projects are in dev mode, they use `image` in the `docker-compose.yml` to mean the desired image tag for the local build, rather than a remote image to pull. This is a valid use case described in Docker docs, and we're doing it to work around another issue with how the override config is applied. However, the `dc pull` command seems to have a bug where it tries to pull that `image` rather than ignoring it because `build` is also specified.

The end result is that `make start` shows an error about not being able to find the image, and this prevents it from starting always.

## Solution
Use a semicolon between the commands instead. This way, it will still do `docker-compose up -d` even if `docker-compose pull` fails. The error still shows in the logs and could confuse people but I can't think of any other easy way to fix this.

## Breaking changes
None

## Testing
Put Reaction Admin or Reaction Identity into dev config mode and ensure `make start` works even though it still prints the error. Something like this:

```sh
# In platform dir
ln -s ./reaction-admin/docker-compose.dev.yml ./reaction-admin/docker-compose.override.yml
make start-reaction-admin
```