### PR TITLE
fix: git fetch before git checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ clone: github-configured $(foreach p,$(SUBPROJECTS),$(p))
 ###############################################################################
 define git-checkout-template
 checkout-$(2): $(2)
-	cd $(2) && git checkout "$(3)"
+	cd $(2) && git fetch && git checkout "$(3)"
 endef
 $(foreach rr,$(SUBPROJECT_REPOS),$(eval $(call git-checkout-template,$(shell echo $(rr) | cut -d , -f 1),$(shell echo $(rr) | cut -d , -f 2),$(shell echo $(rr) | cut -d , -f 3))))
 


### PR DESCRIPTION
Impact: **minor**  
Type: **bugfix**

## Issue
The `make checkout` command can result in `"pathspec 'v3.0.0-alpha.2' did not match any file(s) known to git"` error when you haven't done `git fetch` on individual repos since the tags referenced in platform were pushed.

## Solution
Updates `make checkout` to always do `git fetch` before `git checkout <tag>`

## Breaking changes
None

## Testing
`make checkout` and verify it works and you see it doing a fetch before every checkout