### PR TITLE
release v3.0.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v3.0.0-beta
+
+This beta release bumps the following projects to their beta releases:
+
+- [reaction](https://github.com/reactioncommerce/reaction/tree/v3.0.0-beta)
+- [example-storefront](https://github.com/reactioncommerce/example-storefront/tree/v3.0.0-beta)
+- [reaction-admin](https://github.com/reactioncommerce/reaction-admin/tree/v3.0.0-beta)
+- [reaction-identity](https://github.com/reactioncommerce/reaction-identity/tree/v3.0.0-beta)
+- [reaction-hydra](https://github.com/reactioncommerce/reaction-hydra/tree/v3.0.0-beta)
+
 # v3.0.0-alpha.3
 
 This alpha release bumps the following projects to their latest alpha releases:

--- a/config.mk
+++ b/config.mk
@@ -27,11 +27,11 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
-git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0-alpha.3 \
-git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-alpha \
-git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0-alpha.2 \
-git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0-alpha.2 \
-git@github.com:/reactioncommerce/reaction.git,reaction,v3.0.0-alpha.3
+git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0-beta \
+git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta \
+git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0-beta \
+git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0-beta \
+git@github.com:/reactioncommerce/reaction.git,reaction,v3.0.0-beta
 endef
 
 # List of user defined networks that should be created.


### PR DESCRIPTION
# v3.0.0-beta

This beta release bumps the following projects to their beta releases:

- [reaction](https://github.com/reactioncommerce/reaction/tree/v3.0.0-beta)
- [example-storefront](https://github.com/reactioncommerce/example-storefront/tree/v3.0.0-beta)
- [reaction-admin](https://github.com/reactioncommerce/reaction-admin/tree/v3.0.0-beta)
- [reaction-identity](https://github.com/reactioncommerce/reaction-identity/tree/v3.0.0-beta)
- [reaction-hydra](https://github.com/reactioncommerce/reaction-hydra/tree/v3.0.0-beta)