### PR TITLE
feature: Add command to start projects in development mode.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ dev-link: $(foreach p,$(SUBPROJECTS),dev-link-$(p))
 ### `ln -s docker-compose.dev.yml docker-compose.override.yml; docker-compose up -d`
 ###############################################################################
 define dev-template
-dev-$(1): dev-link-$(1) start-$(1)
+dev-$(1): stop-$(1) dev-link-$(1) start-$(1)
 endef
 $(foreach p,$(SUBPROJECTS),$(eval $(call dev-template,$(p))))
 
@@ -256,7 +256,7 @@ dev: $(foreach p,$(SUBPROJECTS),dev-$(p))
 ###
 ### Pull the specified image tags every time. Tags are constantly being updated
 ### to point to different image IDs, and there is less to debug if we can be
-### reasonably sure that you're always starting the latest image with that tag.
+### reasonably to make sure that you're always starting the latest image with that tag.
 ###
 ### We are purposely running dc up even if dc pull fails. Our Meteor project DC
 ### config uses `image` as a desired image tag for `build` when in dev mode. But

--- a/Makefile
+++ b/Makefile
@@ -215,12 +215,12 @@ dev-$(1):
 	@if [ -e "$(1)/docker-compose.dev.yml" ]; then \
 	  echo "Starting $(1) in development mode" \
 	  && cd $(1) \
-		&& rm -rf docker-compose.override.yml \
-		&& ln -s docker-compose.dev.yml docker-compose.override.yml \
+		&& ln -sf docker-compose.dev.yml docker-compose.override.yml \
 		&& docker-compose up -d; \
 	else \
 	  echo "Starting $(1) from docker image" \
 	  && cd $(1) \
+    && docker-compose down \
 		&& docker-compose up -d; \
 	fi;
 endef

--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,29 @@ $(foreach p,$(SUBPROJECTS),$(eval $(call post-build-template,$(p))))
 .PHONY: post-build
 post-build: $(foreach p,$(SUBPROJECTS),post-build-$(p))
 
+###############################################################################
+### dev
+### Starts services in development mode with
+### `ln -s docker-compose.dev.yml docker-compose.override.yml; docker-compose up -d`
+###############################################################################
+define dev-template
+dev-$(1):
+	@if [ -e "$(1)/docker-compose.dev.yml" ]; then \
+	  echo "Starting $(1) in development mode" \
+	  && cd $(1) \
+		&& rm -rf docker-compose.override.yml \
+		&& ln -s docker-compose.dev.yml docker-compose.override.yml \
+		&& docker-compose up -d; \
+	else \
+	  echo "Starting $(1) from docker image" \
+	  && cd $(1) \
+		&& docker-compose up -d; \
+	fi;
+endef
+$(foreach p,$(SUBPROJECTS),$(eval $(call dev-template,$(p))))
+
+.PHONY: dev
+dev: $(foreach p,$(SUBPROJECTS),dev-$(p))
 
 ###############################################################################
 ### Start

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ These are the available `make` commands in the `reaction-platform` root director
 | `make stop-<project-name>`                              | Example: `make stop-example-storefront`. Stops all containers for a single project.                                                             |
 | `make start`                                            | Starts all containers.                                                                                                                          |
 | `make start-<project-name>`                             | Example: `make start-example-storefront`. Starts all containers for a single project.                                                           |
+| `make dev`                                              | Starts `reaction`, `reaction-admin`, `example-storefront` and `reaction-identity` in development mode. |
+| `make dev-<project-name>`                               | Example: `make dev-example-storefront`. Starts all containers for a single project in development mode.
 | `make rm`                                               | Removes all containers. Volumes are not removed.                                                                                                |
 | `make rm-<project-name>`                                | Example: `make rm-example-storefront`. Removes all containers for a single project. Volumes are not removed.                                    |
 | `make checkout-<project-name> <git-tag-or-branch-name>` | Example: `make checkout-example-storefront release-v3.0.0`. Does `git checkout` for a sub-project. See "Running Particular Git Branches" below. |
@@ -104,11 +106,8 @@ To ensure they start quickly, all Reaction projects are configured (in their `do
 # Stop the project
 make stop-<project-name>
 
-# Create a Docker Compose override file for the project
-ln -s ./<project-name>/docker-compose.dev.yml ./<project-name>/docker-compose.override.yml
-
-# Start the project
-make start-<project-name>
+# Start the project in development mode
+make dev-<project-name>
 ```
 
 If you run into trouble with the above steps, `make clean-<project-name>` and then `make init-<project-name>`.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ These are the available `make` commands in the `reaction-platform` root director
 | `make start-<project-name>`                             | Example: `make start-example-storefront`. Starts all containers for a single project.                                                           |
 | `make dev`                                              | Starts `reaction`, `reaction-admin`, `example-storefront` and `reaction-identity` in development mode. |
 | `make dev-<project-name>`                               | Example: `make dev-example-storefront`. Starts all containers for a single project in development mode.
+| `make dev-link`                                         | Creates development symlinks for `reaction`, `reaction-admin`, `example-storefront` and `reaction-identity`. |
+| `make dev-link-<project-name>`                          | Example: `make dev-link-example-storefront`. Creates development symlinks for a single project.
+| `make dev-unlink`                                       | Removes development symlinks for `reaction`, `reaction-admin`, `example-storefront` and `reaction-identity`. |
+| `make dev-unlink-<project-name>`                        | Example: `make dev-unlink-example-storefront`. Removes development symlinks for a single project.
 | `make rm`                                               | Removes all containers. Volumes are not removed.                                                                                                |
 | `make rm-<project-name>`                                | Example: `make rm-example-storefront`. Removes all containers for a single project. Volumes are not removed.                                    |
 | `make checkout-<project-name> <git-tag-or-branch-name>` | Example: `make checkout-example-storefront release-v3.0.0`. Does `git checkout` for a sub-project. See "Running Particular Git Branches" below. |

--- a/README.md
+++ b/README.md
@@ -107,14 +107,10 @@ If you're getting unexpected results, `cd` into the sub-project directory and do
 To ensure they start quickly, all Reaction projects are configured (in their `docker-compose.yml` file) to run from the latest published Docker image. This means that if you change code files, you will not see your changes reflected in the running application. To switch over to development mode for a single project:
 
 ```sh
-# Stop the project
-make stop-<project-name>
-
-# Start the project in development mode
 make dev-<project-name>
 ```
 
-If you run into trouble with the above steps, `make clean-<project-name>` and then `make init-<project-name>`.
+If you run into trouble with the above command, run `make clean-<project-name>` and then `make init-<project-name>`.
 
 ## Networked Services
 


### PR DESCRIPTION
Resolves https://github.com/reactioncommerce/reaction-platform/issues/83
Impact: **minor**  
Type: **featur**

## Issue
There was no `make` command to start projects in development mode

## Solution
Add `make dev` and `make dev-<project-name>` command to start projects in development mode.

## Breaking changes
None


## Testing
1. run `make dev` and `make dev-<project-name>`
2. make sure `docker-compose.override.yml` file gets created in the respective projects
3. Make sure the docker-compose runs using the local files and not using the image from Dockerhub

