### PR TITLE
fix: Reorder subprojects based on dependency order for startup

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -27,11 +27,11 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
-git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0-beta \
-git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta \
 git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0-beta \
 git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0-beta \
-git@github.com:/reactioncommerce/reaction.git,reaction,v3.0.0-beta
+git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta \
+git@github.com:/reactioncommerce/reaction.git,reaction,v3.0.0-beta \
+git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0-beta
 endef
 
 # List of user defined networks that should be created.


### PR DESCRIPTION
Impact: **minor**  
Type: **refactor**

## Issue

List subprojects in startup dependency order just for clarity. This doesn't guarantee clean startup or account for the delay between service start and service ready but it at least is logical.


Based on @trojanh's comment here: https://github.com/reactioncommerce/reaction-platform/pull/97#issuecomment-577608532

## Breaking changes
Not breaking.

## Testing
1. Test startup, making sure you don't override `SUBPROJECT_REPOS` in `config.local.mk`

