### PR TITLE
feature: Add command to start projects in development mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,16 +38,28 @@ all: init
 
 ###############################################################################
 ### Init-Project
-### Initializes a project. Does not do common tasks shared between projects.
+### Initializes a project in production mode.
+### Does not do common tasks shared between projects.
 ###############################################################################
 define init-template
-init-$(1): $(1) network-create prebuild-$(1) build-$(1) post-build-$(1) start-$(1) post-project-start-$(1)
+init-$(1): $(1) network-create dev-unlink-$(1) prebuild-$(1) build-$(1) post-build-$(1) start-$(1) post-project-start-$(1)
 endef
 $(foreach p,$(SUBPROJECTS),$(eval $(call init-template,$(p))))
 
 ###############################################################################
-### Init Project with System
-### Init project and run the post-system hook script.
+### Init-Dev-Project
+### Initializes a project in development mode.
+### Does not do common tasks shared between projects.
+###############################################################################
+define init-dev-template
+init-dev-$(1): $(1) network-create dev-link-$(1) prebuild-$(1) build-$(1) post-build-$(1) start-$(1) post-project-start-$(1)
+endef
+$(foreach p,$(SUBPROJECTS),$(eval $(call init-dev-template,$(p))))
+
+###############################################################################
+### Init-With-System
+### Init project and run the post-system hook script. This is useful for
+### initializing a single project.
 ### Assumes dependencies are already started.
 ###############################################################################
 define init-with-system-template
@@ -55,8 +67,22 @@ init-with-system-$(1): init-$(1) post-system-start-$(1)
 endef
 $(foreach p,$(SUBPROJECTS),$(eval $(call init-with-system-template,$(p))))
 
+###############################################################################
+### Init-Dev-with-System
+### Init project and run the post-system hook script. This is useful for
+### initializing a single project in development mode.
+### Assumes dependencies are already started.
+###############################################################################
+define init-dev-with-system-template
+init-dev-with-system-$(1): init-dev-$(1) post-system-start-$(1)
+endef
+$(foreach p,$(SUBPROJECTS),$(eval $(call init-dev-with-system-template,$(p))))
+
 .PHONY: init
 init: $(foreach p,$(SUBPROJECTS),init-$(p)) post-system-start
+
+.PHONY: init-dev
+init-dev: $(foreach p,$(SUBPROJECTS),init-dev-$(p)) post-system-start
 
 ###############################################################################
 ### Targets to verify Github is configured correctly.

--- a/Makefile
+++ b/Makefile
@@ -273,9 +273,6 @@ dev-$(1): stop-$(1) dev-link-$(1) start-$(1)
 endef
 $(foreach p,$(SUBPROJECTS),$(eval $(call dev-template,$(p))))
 
-.PHONY: dev
-dev: $(foreach p,$(SUBPROJECTS),dev-$(p))
-
 ###############################################################################
 ### Start
 ### Starts services with `docker-compose up -d`

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ dev-link: $(foreach p,$(SUBPROJECTS),dev-link-$(p))
 ### `ln -s docker-compose.dev.yml docker-compose.override.yml; docker-compose up -d`
 ###############################################################################
 define dev-template
-dev-$(1): dev-link-$(1) start-$(1)
+dev-$(1): stop-$(1) dev-link-$(1) start-$(1)
 endef
 $(foreach p,$(SUBPROJECTS),$(eval $(call dev-template,$(p))))
 
@@ -256,7 +256,7 @@ dev: $(foreach p,$(SUBPROJECTS),dev-$(p))
 ###
 ### Pull the specified image tags every time. Tags are constantly being updated
 ### to point to different image IDs, and there is less to debug if we can be
-### reasonably sure that you're always starting the latest image with that tag.
+### reasonably to make sure that you're always starting the latest image with that tag.
 ###
 ### We are purposely running dc up even if dc pull fails. Our Meteor project DC
 ### config uses `image` as a desired image tag for `build` when in dev mode. But

--- a/Makefile
+++ b/Makefile
@@ -215,12 +215,12 @@ dev-$(1):
 	@if [ -e "$(1)/docker-compose.dev.yml" ]; then \
 	  echo "Starting $(1) in development mode" \
 	  && cd $(1) \
-		&& rm -rf docker-compose.override.yml \
-		&& ln -s docker-compose.dev.yml docker-compose.override.yml \
+		&& ln -sf docker-compose.dev.yml docker-compose.override.yml \
 		&& docker-compose up -d; \
 	else \
 	  echo "Starting $(1) from docker image" \
 	  && cd $(1) \
+    && docker-compose down \
 		&& docker-compose up -d; \
 	fi;
 endef

--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,29 @@ $(foreach p,$(SUBPROJECTS),$(eval $(call post-build-template,$(p))))
 .PHONY: post-build
 post-build: $(foreach p,$(SUBPROJECTS),post-build-$(p))
 
+###############################################################################
+### dev
+### Starts services in development mode with
+### `ln -s docker-compose.dev.yml docker-compose.override.yml; docker-compose up -d`
+###############################################################################
+define dev-template
+dev-$(1):
+	@if [ -e "$(1)/docker-compose.dev.yml" ]; then \
+	  echo "Starting $(1) in development mode" \
+	  && cd $(1) \
+		&& rm -rf docker-compose.override.yml \
+		&& ln -s docker-compose.dev.yml docker-compose.override.yml \
+		&& docker-compose up -d; \
+	else \
+	  echo "Starting $(1) from docker image" \
+	  && cd $(1) \
+		&& docker-compose up -d; \
+	fi;
+endef
+$(foreach p,$(SUBPROJECTS),$(eval $(call dev-template,$(p))))
+
+.PHONY: dev
+dev: $(foreach p,$(SUBPROJECTS),dev-$(p))
 
 ###############################################################################
 ### Start

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ These are the available `make` commands in the `reaction-platform` root director
 | `make stop-<project-name>`                              | Example: `make stop-example-storefront`. Stops all containers for a single project.                                                             |
 | `make start`                                            | Starts all containers.                                                                                                                          |
 | `make start-<project-name>`                             | Example: `make start-example-storefront`. Starts all containers for a single project.                                                           |
+| `make dev`                                              | Starts `reaction`, `reaction-admin`, `example-storefront` and `reaction-identity` in development mode. |
+| `make dev-<project-name>`                               | Example: `make dev-example-storefront`. Starts all containers for a single project in development mode.
 | `make rm`                                               | Removes all containers. Volumes are not removed.                                                                                                |
 | `make rm-<project-name>`                                | Example: `make rm-example-storefront`. Removes all containers for a single project. Volumes are not removed.                                    |
 | `make checkout-<project-name> <git-tag-or-branch-name>` | Example: `make checkout-example-storefront release-v3.0.0`. Does `git checkout` for a sub-project. See "Running Particular Git Branches" below. |
@@ -104,11 +106,8 @@ To ensure they start quickly, all Reaction projects are configured (in their `do
 # Stop the project
 make stop-<project-name>
 
-# Create a Docker Compose override file for the project
-ln -s ./<project-name>/docker-compose.dev.yml ./<project-name>/docker-compose.override.yml
-
-# Start the project
-make start-<project-name>
+# Start the project in development mode
+make dev-<project-name>
 ```
 
 If you run into trouble with the above steps, `make clean-<project-name>` and then `make init-<project-name>`.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ make <start-project-name>
 
 If you run into trouble with the above command, run `make clean-<project-name>` and then `make init-dev-<project-name>`.
 
-##### To switch back to development mode for a single project:
+##### To switch back to production mode for a single project:
 
 ```sh
 make stop-<project-name>

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ These are the available `make` commands in the `reaction-platform` root director
 | `make start-<project-name>`                             | Example: `make start-example-storefront`. Starts all containers for a single project.                                                           |
 | `make dev`                                              | Starts `reaction`, `reaction-admin`, `example-storefront` and `reaction-identity` in development mode. |
 | `make dev-<project-name>`                               | Example: `make dev-example-storefront`. Starts all containers for a single project in development mode.
+| `make dev-link`                                         | Creates development symlinks for `reaction`, `reaction-admin`, `example-storefront` and `reaction-identity`. |
+| `make dev-link-<project-name>`                          | Example: `make dev-link-example-storefront`. Creates development symlinks for a single project.
+| `make dev-unlink`                                       | Removes development symlinks for `reaction`, `reaction-admin`, `example-storefront` and `reaction-identity`. |
+| `make dev-unlink-<project-name>`                        | Example: `make dev-unlink-example-storefront`. Removes development symlinks for a single project.
 | `make rm`                                               | Removes all containers. Volumes are not removed.                                                                                                |
 | `make rm-<project-name>`                                | Example: `make rm-example-storefront`. Removes all containers for a single project. Volumes are not removed.                                    |
 | `make checkout-<project-name> <git-tag-or-branch-name>` | Example: `make checkout-example-storefront release-v3.0.0`. Does `git checkout` for a sub-project. See "Running Particular Git Branches" below. |

--- a/README.md
+++ b/README.md
@@ -68,18 +68,19 @@ These are the available `make` commands in the `reaction-platform` root director
 
 | Command                                                 | Description                                                                                                                                     |
 |---------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
-| `make`                                                  | Bootstraps the entire Reaction development environment in Docker.                                                                               |
+| `make`                                                  | Bootstraps the entire Reaction development environment in Docker. Projects will use production Docker images and code.                          |
 | `make init-<project-name>`                              | Example: `make init-example-storefront`. Does clone/setup for a single project.                                                                 |
+| `make init-dev`                                         | Boostraps the entire Reaction development environment in Docker. Projects will use development configuration.                                   |
+| `make init-dev-<project-name>`                          | Example: `make init-dev-example-storefront`. Does clone/setup for a single project and configures it with a development configuration.          |                                                       |
 | `make stop`                                             | Stops all containers.                                                                                                                           |
 | `make stop-<project-name>`                              | Example: `make stop-example-storefront`. Stops all containers for a single project.                                                             |
 | `make start`                                            | Starts all containers.                                                                                                                          |
 | `make start-<project-name>`                             | Example: `make start-example-storefront`. Starts all containers for a single project.                                                           |
-| `make dev`                                              | Starts `reaction`, `reaction-admin`, `example-storefront` and `reaction-identity` in development mode. |
 | `make dev-<project-name>`                               | Example: `make dev-example-storefront`. Starts all containers for a single project in development mode.
-| `make dev-link`                                         | Creates development symlinks for `reaction`, `reaction-admin`, `example-storefront` and `reaction-identity`. |
-| `make dev-link-<project-name>`                          | Example: `make dev-link-example-storefront`. Creates development symlinks for a single project.
-| `make dev-unlink`                                       | Removes development symlinks for `reaction`, `reaction-admin`, `example-storefront` and `reaction-identity`. |
-| `make dev-unlink-<project-name>`                        | Example: `make dev-unlink-example-storefront`. Removes development symlinks for a single project.
+| `make dev-link`                                         | Creates `docker-compose.override.yml` symlinks for development in all projects.                                                                 |
+| `make dev-link-<project-name>`                          | Example: `make dev-link-example-storefront`. Creates development symlinks for a single project.                                                 |
+| `make dev-unlink`                                       | Removes `docker-compose.override.yml` symlinks from all projects.                                                                               |
+| `make dev-unlink-<project-name>`                        | Example: `make dev-unlink-example-storefront`. Removes the `docker-compose.override.yml` symlink for a single project.                          |                     |
 | `make rm`                                               | Removes all containers. Volumes are not removed.                                                                                                |
 | `make rm-<project-name>`                                | Example: `make rm-example-storefront`. Removes all containers for a single project. Volumes are not removed.                                    |
 | `make checkout-<project-name> <git-tag-or-branch-name>` | Example: `make checkout-example-storefront release-v3.0.0`. Does `git checkout` for a sub-project. See "Running Particular Git Branches" below. |
@@ -104,10 +105,30 @@ If you're getting unexpected results, `cd` into the sub-project directory and do
 
 ### Running From Code For Development
 
-To ensure they start quickly, all Reaction projects are configured (in their `docker-compose.yml` file) to run from the latest published Docker image. This means that if you change code files, you will not see your changes reflected in the running application. To switch over to development mode for a single project:
+To ensure they start quickly, all Reaction projects are configured (in their `docker-compose.yml` file) to run from the latest published Docker image. This means that if you change code files, you will not see your changes reflected in the running application. 
+
+##### To install the whole platform in development mode:
+
+Run `make init-dev` (instead of `make`).
+
+Doing this takes time to install and will consume more resources.
+
+##### To switch over to development mode for a single project:
 
 ```sh
-make dev-<project-name>
+make stop-<project-name>
+make dev-link-<project-name>
+make <start-project-name>
+```
+
+If you run into trouble with the above command, run `make clean-<project-name>` and then `make init-dev-<project-name>`.
+
+##### To switch back to development mode for a single project:
+
+```sh
+make stop-<project-name>
+make dev-unlink-<project-name>
+make <start-project-name>
 ```
 
 If you run into trouble with the above command, run `make clean-<project-name>` and then `make init-<project-name>`.

--- a/README.md
+++ b/README.md
@@ -107,14 +107,10 @@ If you're getting unexpected results, `cd` into the sub-project directory and do
 To ensure they start quickly, all Reaction projects are configured (in their `docker-compose.yml` file) to run from the latest published Docker image. This means that if you change code files, you will not see your changes reflected in the running application. To switch over to development mode for a single project:
 
 ```sh
-# Stop the project
-make stop-<project-name>
-
-# Start the project in development mode
 make dev-<project-name>
 ```
 
-If you run into trouble with the above steps, `make clean-<project-name>` and then `make init-<project-name>`.
+If you run into trouble with the above command, run `make clean-<project-name>` and then `make init-<project-name>`.
 
 ## Networked Services
 


### PR DESCRIPTION
Resolves #97, #83
Impact: **minor**  
Type: **feature**

## Issue
There was no make command to start projects in development mode.

## Solution
This continues the work that @trojanh started in #97. Thanks for the submission @trojanh! 

 Add `make init-dev` and `make dev-<project-name>` command to start projects in development mode.

This makes some additions to create init tasks that will configure project(s) for "development mode", which means that `docker-compose.dev.yml` is symlinked to `docker-compose.override.yml` in the project directory. The dev overrides configure the project to build and mount local code into the project. That's usually slower.

The README contains workflow suggestions.

I removed the global `dev` target that was originally proposed, but left the per-project `dev-<project>` tasks undocumented in the README. Is stopping enough? The README shows documents stopping (same as `dev-<project>`) but the explicit operations make it clear to user what's happening. Happy to document it in the README  if we're confident the workflow will work for everyone and not trigger more support cases.

## Breaking changes
None.

## Testing
We had some discussion in #98. I think there was some confusion around the expected workflow. So here are testing instructions for a few cases:

### Start Everything in Dev Mode
You probably don't want to do this anymore! It's slow and takes more resources.

1. `git clone git@github.com:reactioncommerce/reaction-development-platform.git`
1. `cd reaction-development-platform`
1. `make init-dev`
1. Make sure docker-compose.override.yml file gets created in the respective projects 
1. Make sure the docker-compose runs using the local files and not using the image from Dockerhub


### Switch a Single Project into Dev Mode
Using instructions from README.

1. `git clone git@github.com:reactioncommerce/reaction-development-platform.git`
1. `cd reaction-development-platform`
1. `make init`
1. Make sure all projects start in "production" mode, using pre-built images and no code mounts.
1. Follow [README instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/development-mode#to-switch-over-to-development-mode-for-a-single-project) to switch to dev mode.
1. Make sure docker-compose.override.yml file gets created in the respective projects
1. Make sure the docker-compose runs using the local files and not using the image from Dockerhub

### Switch a Single Project into Dev Mode
Using experimental `make dev-<project>` target. It's undocumented in README until we have high confidence that it works well.

1. `git clone git@github.com:reactioncommerce/reaction-development-platform.git`
1. `cd reaction-development-platform`
1. `make init`
1. Make sure all projects start in "production" mode, using pre-built images and no code mounts.
1. Run `make dev-<project>`
1. Make sure docker-compose.override.yml file gets created in the respective projects
1. Make sure the docker-compose runs using the local files and not using the image from Dockerhub


### Switch a Single Project into Production Mode

1. Follow above instructions to ensure a project is in dev mode.
1. Follow [README instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/development-mode#to-switch-back-to-production-mode-for-a-single-project) to switch to prod mode.
1. Make sure `docker-compose.override.yml` file is removed in the respective projects
1. Make sure the docker-compose runs using Dockerhub image and does not mount code.