### PR TITLE
release v3.0.0-beta.3 to update reaction-admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v3.0.0-beta.3
+
+This beta release bumps the following projects to their latest beta releases:
+
+- [reaction-admin](https://github.com/reactioncommerce/reaction-admin/tree/v3.0.0-beta.2)
+
 # v3.0.0-beta.2
 
 This beta release bumps the following projects to their latest beta releases:

--- a/config.mk
+++ b/config.mk
@@ -29,7 +29,7 @@ endef
 define SUBPROJECT_REPOS
 git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0-beta \
 git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0-beta \
-git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta \
+git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.2 \
 git@github.com:/reactioncommerce/reaction.git,reaction,v3.0.0-beta.2 \
 git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0-beta
 endef


### PR DESCRIPTION
# v3.0.0-beta.3

This beta release bumps the following projects to their latest beta releases:

- [reaction-admin](https://github.com/reactioncommerce/reaction-admin/tree/v3.0.0-beta.2)