### PR TITLE
release v3.0.0-beta.4: update all projects for their beta releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v3.0.0-beta.4
+
+This beta release bumps the following projects to their latest beta releases:
+
+- [reaction](https://github.com/reactioncommerce/reaction-admin/tree/v3.0.0-beta.3)
+- [example-storefront](https://github.com/reactioncommerce/example-storefront/tree/v3.0.0-beta.2)
+- [reaction-admin](https://github.com/reactioncommerce/reaction-admin/tree/v3.0.0-beta.3)
+- [reaction-hydra](https://github.com/reactioncommerce/reaction-hydra/tree/v3.0.0-beta.2)
+- [reaction-identity](https://github.com/reactioncommerce/reaction-identity/tree/v3.0.0-beta.2)
+
 # v3.0.0-beta.3
 
 This beta release bumps the following projects to their latest beta releases:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This beta release bumps the following projects to their latest beta releases:
 - [reaction-hydra](https://github.com/reactioncommerce/reaction-hydra/tree/v3.0.0-beta.2)
 - [reaction-identity](https://github.com/reactioncommerce/reaction-identity/tree/v3.0.0-beta.2)
 
+This release also includes the following PR's:
+
+## Features
+
+- feat: add command to start projects in development mode [#99](https://github.com/reactioncommerce/reaction-development-platform/pull/99)
+- feat: consolidate to one external network [#101](https://github.com/reactioncommerce/reaction-development-platform/pull/101)
+
 # v3.0.0-beta.3
 
 This beta release bumps the following projects to their latest beta releases:

--- a/config.mk
+++ b/config.mk
@@ -27,11 +27,11 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
-git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0-beta \
-git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0-beta \
-git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.2 \
-git@github.com:/reactioncommerce/reaction.git,reaction,v3.0.0-beta.2 \
-git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0-beta
+git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0-beta.2 \
+git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0-beta.2 \
+git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.3 \
+git@github.com:/reactioncommerce/reaction.git,reaction,v3.0.0-beta.3 \
+git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0-beta.2
 endef
 
 # List of user defined networks that should be created.


### PR DESCRIPTION
# v3.0.0-beta.4

This beta release bumps the following projects to their latest beta releases:

- [reaction](https://github.com/reactioncommerce/reaction-admin/tree/v3.0.0-beta.3)
- [example-storefront](https://github.com/reactioncommerce/example-storefront/tree/v3.0.0-beta.2)
- [reaction-admin](https://github.com/reactioncommerce/reaction-admin/tree/v3.0.0-beta.3)
- [reaction-hydra](https://github.com/reactioncommerce/reaction-hydra/tree/v3.0.0-beta.2)
- [reaction-identity](https://github.com/reactioncommerce/reaction-identity/tree/v3.0.0-beta.2)

This release also includes the following PR's:

## Features

- feat: add command to start projects in development mode [#99](https://github.com/reactioncommerce/reaction-development-platform/pull/99)
- feat: consolidate to one external network [#101](https://github.com/reactioncommerce/reaction-development-platform/pull/101)