### PR TITLE
release v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+# v3.0.2
+
+This update is coordinated with the release of [reaction 3.1.0](https://github.com/reactioncommerce/reaction/releases/tag/v3.1.0) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
+
 # v3.0.1
 
-This update is coordinated with the release of [reaction-admin 3.0.0-beta.5](https://github.com/reactioncommerce/reaction-admin) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
+This update is coordinated with the release of [reaction-admin 3.0.0-beta.5](https://github.com/reactioncommerce/reaction-admin/releases/tag/v3.0.0) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
 
 # v3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # v3.0.2
 
-This update is coordinated with the release of [reaction 3.1.0](https://github.com/reactioncommerce/reaction/releases/tag/v3.1.0) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
+This update is coordinated with the release of [Reaction v3.1.0](https://github.com/reactioncommerce/reaction/releases/tag/v3.1.0) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
 
 # v3.0.1
 
-This update is coordinated with the release of [reaction-admin 3.0.0-beta.5](https://github.com/reactioncommerce/reaction-admin/releases/tag/v3.0.0) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
+This update is coordinated with the release of [Reaction Admin v3.0.0-beta.5](https://github.com/reactioncommerce/reaction-admin/releases/tag/v3.0.0) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
 
 # v3.0.0
 

--- a/README.md
+++ b/README.md
@@ -168,12 +168,12 @@ The following table provides the most current version of each project used by th
 | Project                             	| Latest release  	|
 |-------------------------------------	|-----------------	|
 | [reaction-development-platform][10] 	| 3.0.1           	|
-| [reaction][10]                      	| 3.0.0           	|
+| [reaction][10]                      	| 3.1.0           	|
 | [reaction-hydra][12]                	| 3.0.0           	|
 | [reaction-identity][17]             	| 3.0.0           	|
 | [example-storefront][13]            	| 3.0.0           	|
 | [reaction-admin (beta)][19]         	| 3.0.0-beta.5    	|
-| [api-migrations][20]                	| 3.0.0           	|
+| [api-migrations][20]                	| 3.1.0           	|
 
 ### Developer Certificate of Origin
 We use the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) in lieu of a Contributor License Agreement for all contributions to Reaction Commerce open source projects. We request that contributors agree to the terms of the DCO and indicate that agreement by signing-off all commits made to Reaction Commerce projects by adding a line with your name and email address to every Git commit message contributed:

--- a/config.mk
+++ b/config.mk
@@ -28,7 +28,7 @@ endef
 # Projects will be started in this order
 define SUBPROJECT_REPOS
 git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
-git@github.com:/reactioncommerce/reaction.git,reaction,v3.0.0 \
+git@github.com:/reactioncommerce/reaction.git,reaction,v3.1.0 \
 git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
 git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.5 \
 git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0


### PR DESCRIPTION
# v3.0.2

This update is coordinated with the release of [reaction 3.1.0](https://github.com/reactioncommerce/reaction/releases/tag/v3.1.0) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.