### PR TITLE
Release configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-!^.github/
+/*/
 !^.docs/
+!^.github/
+!config/
+/config/local/
+!config/local/.gitkeep
 config.local.mk
-*/

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,12 @@
 #
 
 ###############################################################################
-### Configuration
+### Common Configuration
+###############################################################################
+HOOK_DIR=.reaction/project-hooks
+
+###############################################################################
+### Loaded Configuration
 ### Load configuration from external files. Configuration variables defined in
 ### later files have precedent and will overwrite those defined in previous
 ### files. The -include directive ensures that no error is thrown if a file is

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,21 @@ $(foreach rr,$(SUBPROJECT_REPOS),$(eval $(call git-clone-template,$(shell echo $
 clone: github-configured $(foreach p,$(SUBPROJECTS),$(p))
 
 ###############################################################################
+### Git Verify Clean
+### Checks that the project has a clean workspace and changes won't be lost.
+###############################################################################
+define git-ensure-clean-diff-template
+git-ensure-clean-diff-$(2): $(2)
+	@cd "$(2)" \
+	  && git diff --stat --quiet \
+	  || (echo "There are uncommitted changes in './$(2)'. Commit or discard changes before performing this operation."; exit 1)
+endef
+$(foreach rr,$(SUBPROJECT_REPOS),$(eval $(call git-ensure-clean-diff-template,$(shell echo $(rr) | cut -d , -f 1),$(shell echo $(rr) | cut -d , -f 2),$(shell echo $(rr) | cut -d , -f 3))))
+
+.PHONY: git-ensure-clean-diff
+git-ensure-clean-diff: $(foreach p,$(SUBPROJECTS),git-ensure-clean-diff-$(p))
+
+###############################################################################
 ### Git checkout
 ### Checkout the branch configured in the platform settings.
 ### Does not gracefully deal with conflicts or other problems.
@@ -179,6 +194,28 @@ $(foreach rr,$(SUBPROJECT_REPOS),$(eval $(call git-checkout-template,$(shell ech
 
 .PHONY: checkout
 checkout: clone $(foreach p,$(SUBPROJECTS),checkout-$(p))
+
+
+###############################################################################
+### Git Update Checkouts
+### Will check out the configured branch for all projects. This can be used to
+### get an installation in sync with the configuration file.
+### Fails on conflicts so the developer can properly commit or discard work.
+###
+### It is important to keep the `git-ensure-clean-diff` dependency, else
+### WORK WILL BE LOST!!
+###############################################################################
+define git-update-checkout-template
+update-checkout-$(2): git-ensure-clean-diff-$(2)
+	cd $(2) \
+	  && git fetch --tags \
+	  && git checkout $(3) \
+	  && git pull origin $(3) --ff-only
+endef
+$(foreach rr,$(SUBPROJECT_REPOS),$(eval $(call git-update-checkout-template,$(shell echo $(rr) | cut -d , -f 1),$(shell echo $(rr) | cut -d , -f 2),$(shell echo $(rr) | cut -d , -f 3))))
+
+.PHONY: update-checkouts
+update-checkouts: $(foreach p,$(SUBPROJECTS),update-checkout-$(p))
 
 ###############################################################################
 ### Pre Build Hook

--- a/README.md
+++ b/README.md
@@ -85,6 +85,90 @@ These are the available `make` commands in the `reaction-platform` root director
 | `make update-checkouts`                                 | Example: `make update-checkouts`. Update git checkouts on all projects. Useful for syncing dev env to config file. Safe, fails on uncommitted changes.
 | `make update-checkout-<project-name>`                   | Example: `make update-checkout-example-storefront`. Checks out branch in config file and pulls. Useful for syncing dev env to config file. Safe, fails on uncommitted changes.
 
+
+## Customizing Configuration
+
+The development platform runs the latest version of Reaction by default, but
+it's possible to select a specific version, or to customize an existing release
+version.
+
+### How Configuration Works
+
+The Reaction development platform uses `make` to run tasks. `make` is aware of
+the task dependency tree and ensures that all required dependencies are met
+when running a task.  The main tasks and functionality for `make` are
+configured in `Makefile`.
+
+Configurations that may change are extracted into `config.mk`. This file is
+checked in to source control and should not be modified. It is always configured
+for the latest Reaction release.
+
+If a file named `config.local.mk` exists then it will be loaded after
+`config.mk`. Settings in `config.local.mk` will override those set in
+`config.mk`. It is ignored by source control.
+
+
+### Running a Specific Reaction Release Version
+
+Configurations for specific Reaction releases (since v3.0.0) are located in
+`config/reaction-oss`. You may symlink or copy any release configuration to
+`config.local.mk`.
+
+For example, this command will configure the platform to run `v3.0.4`:
+
+```sh
+ln -s config/reaction-oss/reaction-v3.0.4.mk config.local.mk
+make
+```
+
+### Running A Customized Installation
+
+You may customize your Reaction installation by modifying `config.local.mk`.
+It's easiest to start with an existing release configuration file and modify it
+as needed. In this way you can:
+
+* Add new sub-projects
+* Remove sub-projects
+* Update the git origin for a sub-project
+* Change the default branch for a sub-project
+* Customize the lifecycle hooks directory to run custom scripts for automation
+
+Configuration files store in `config/local` are ignored by git. It's a
+convenient place to store local files for quick development. If you are sharing
+files with a team then you may want to keep your configuration files in a
+separate git repository or in shared network storage.
+
+The only requirement to override configuration is that you need to put a file
+into place at `config.local.mk`, so it is possible to copy or symlink a file
+from anywhere in your system.
+
+Examples:
+
+```sh
+# Use a file in the config/local directory
+ln -s config/local/my-custom-config.mk config.local.mk
+make
+```
+
+```sh
+# Use a file in the config/local directory
+ln -s /path/on/my/system/reactionconfig.mk config.local.mk
+make
+```
+
+### Updating Local Branches to Match Config
+
+If you are using the Reaction development platform for development, then you
+will need to update your local branch to get the latest at some point. The
+`update-checkouts` command will perform this operation.
+
+```
+make update-checkouts
+```
+
+The command is safe. It will halt if there are uncommitted changes in
+git before doing anything. You may commit, stash or drop those changes.
+
 ## Running Particular Git Branches
 
 After you've done the "Getting Started" steps and have the latest Reaction system running, you may need to switch to and run a certain branch/tag in one or more of the sub-projects.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ These are the available `make` commands in the `reaction-platform` root director
 | `make checkout-<project-name> <git-tag-or-branch-name>` | Example: `make checkout-example-storefront release-v3.0.0`. Does `git checkout` for a sub-project. See "Running Particular Git Branches" below. |
 | `make clean`                                            | Removes all containers, networks, and volumes. Any volume data will be lost.                                                                    |
 | `make clean-<project-name>`                             | Example: `make clean-example-storefront`. Removes all containers, networks, and volumes for a single project. Any volume data will be lost.     |
+| `make update-checkouts`                                 | Example: `make update-checkouts`. Update git checkouts on all projects. Useful for syncing dev env to config file. Safe, fails on uncommitted changes.
+| `make update-checkout-<project-name>`                   | Example: `make update-checkout-example-storefront`. Checks out branch in config file and pulls. Useful for syncing dev env to config file. Safe, fails on uncommitted changes.
 
 ## Running Particular Git Branches
 

--- a/config.mk
+++ b/config.mk
@@ -38,5 +38,3 @@ endef
 define DOCKER_NETWORKS
 reaction.localhost
 endef
-
-HOOK_DIR=.reaction/project-hooks

--- a/config/reaction-oss/reaction-v3.0.0.mk
+++ b/config/reaction-oss/reaction-v3.0.0.mk
@@ -1,0 +1,34 @@
+###############################################################################
+### Reaction OSS v3.0.0
+###
+### See: `/config.mk` for documentation.
+###############################################################################
+
+# List of tools that must be installed.
+# A simple check to determine the tool is available. No version check, etc.
+define REQUIRED_SOFTWARE
+docker \
+docker-compose \
+git \
+node \
+yarn
+endef
+
+# Defined here are the subprojects in a comma-separated format
+# GIT_REPO_URL,SUBDIR_NAME,TAG
+# GIT_REPO_URL is the URL of the git repository
+# SUBDIR_NAME is just the directory name itself
+# TAG is the git tag or branch to checkout
+# Projects will be started in this order
+define SUBPROJECT_REPOS
+git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
+git@github.com:/reactioncommerce/reaction.git,reaction,v3.0.0 \
+git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
+git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.4 \
+git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
+endef
+
+# List of user defined networks that should be created.
+define DOCKER_NETWORKS
+reaction.localhost
+endef

--- a/config/reaction-oss/reaction-v3.0.1.mk
+++ b/config/reaction-oss/reaction-v3.0.1.mk
@@ -1,0 +1,34 @@
+###############################################################################
+### Reaction OSS v3.0.1
+###
+### See: `/config.mk` for documentation.
+###############################################################################
+
+# List of tools that must be installed.
+# A simple check to determine the tool is available. No version check, etc.
+define REQUIRED_SOFTWARE
+docker \
+docker-compose \
+git \
+node \
+yarn
+endef
+
+# Defined here are the subprojects in a comma-separated format
+# GIT_REPO_URL,SUBDIR_NAME,TAG
+# GIT_REPO_URL is the URL of the git repository
+# SUBDIR_NAME is just the directory name itself
+# TAG is the git tag or branch to checkout
+# Projects will be started in this order
+define SUBPROJECT_REPOS
+git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
+git@github.com:/reactioncommerce/reaction.git,reaction,v3.0.0 \
+git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
+git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.5 \
+git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
+endef
+
+# List of user defined networks that should be created.
+define DOCKER_NETWORKS
+reaction.localhost
+endef

--- a/config/reaction-oss/reaction-v3.0.2.mk
+++ b/config/reaction-oss/reaction-v3.0.2.mk
@@ -1,0 +1,34 @@
+###############################################################################
+### Reaction OSS v3.0.2
+###
+### See: `/config.mk` for documentation.
+###############################################################################
+
+# List of tools that must be installed.
+# A simple check to determine the tool is available. No version check, etc.
+define REQUIRED_SOFTWARE
+docker \
+docker-compose \
+git \
+node \
+yarn
+endef
+
+# Defined here are the subprojects in a comma-separated format
+# GIT_REPO_URL,SUBDIR_NAME,TAG
+# GIT_REPO_URL is the URL of the git repository
+# SUBDIR_NAME is just the directory name itself
+# TAG is the git tag or branch to checkout
+# Projects will be started in this order
+define SUBPROJECT_REPOS
+git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
+git@github.com:/reactioncommerce/reaction.git,reaction,v3.1.0 \
+git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
+git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.5 \
+git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
+endef
+
+# List of user defined networks that should be created.
+define DOCKER_NETWORKS
+reaction.localhost
+endef

--- a/config/reaction-oss/reaction-v3.0.3.mk
+++ b/config/reaction-oss/reaction-v3.0.3.mk
@@ -1,0 +1,34 @@
+###############################################################################
+### Reaction OSS v3.0.3
+###
+### See: `/config.mk` for documentation.
+###############################################################################
+
+# List of tools that must be installed.
+# A simple check to determine the tool is available. No version check, etc.
+define REQUIRED_SOFTWARE
+docker \
+docker-compose \
+git \
+node \
+yarn
+endef
+
+# Defined here are the subprojects in a comma-separated format
+# GIT_REPO_URL,SUBDIR_NAME,TAG
+# GIT_REPO_URL is the URL of the git repository
+# SUBDIR_NAME is just the directory name itself
+# TAG is the git tag or branch to checkout
+# Projects will be started in this order
+define SUBPROJECT_REPOS
+git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
+git@github.com:/reactioncommerce/reaction.git,reaction,v3.1.0 \
+git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
+git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.5 \
+git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
+endef
+
+# List of user defined networks that should be created.
+define DOCKER_NETWORKS
+reaction.localhost
+endef

--- a/config/reaction-oss/reaction-v3.0.4.mk
+++ b/config/reaction-oss/reaction-v3.0.4.mk
@@ -1,0 +1,34 @@
+###############################################################################
+### Reaction OSS v3.0.4
+###
+### See: `/config.mk` for documentation.
+###############################################################################
+
+# List of tools that must be installed.
+# A simple check to determine the tool is available. No version check, etc.
+define REQUIRED_SOFTWARE
+docker \
+docker-compose \
+git \
+node \
+yarn
+endef
+
+# Defined here are the subprojects in a comma-separated format
+# GIT_REPO_URL,SUBDIR_NAME,TAG
+# GIT_REPO_URL is the URL of the git repository
+# SUBDIR_NAME is just the directory name itself
+# TAG is the git tag or branch to checkout
+# Projects will be started in this order
+define SUBPROJECT_REPOS
+git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
+git@github.com:/reactioncommerce/reaction.git,reaction,v3.3.0 \
+git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
+git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.5 \
+git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
+endef
+
+# List of user defined networks that should be created.
+define DOCKER_NETWORKS
+reaction.localhost
+endef


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Issue
Changes to add versioned releases to the project. We now have a repository of releases since `v3.0.0`. Also includes tooling to get local state synced with configured remotes. Includes docs on how config works and how to select a specific release version.

## Solution

### How Configuration Works

_This is not changed. Only added documentation._

The Reaction development platform uses `make` to run tasks. `make` is aware of
the task dependency tree and ensures that all required dependencies are met
when running a task.  The main tasks and functionality for `make` are
configured in `Makefile`.

Configurations that may change are extracted into `config.mk`. This file is
checked in to source control and should not be modified. It is always configured
for the latest Reaction release.

If a file named `config.local.mk` exists then it will be loaded after
`config.mk`. Settings in `config.local.mk` will override those set in
`config.mk`. It is ignored by source control.

### Running a Specific Reaction Release Version

Configurations for specific Reaction releases (since v3.0.0) are located in
`config/reaction-oss`. You may symlink or copy any release configuration to
`config.local.mk`.

For example, this command will configure the platform to run `v3.0.4`:

```sh
ln -s config/reaction-oss/reaction-v3.0.4.mk
make
```
### Running A Completely Customized Installation

You may customize your Reaction installation by modifying `config.local.mk`.
It's easiest to start with an existing release configuration file and modify it
as needed. In this way you can:

    * Add new sub-projects
    * Remove sub-projects
    * Update the git origin for a sub-project
    * Change the default branch for a sub-project
    * Customize the lifecycle hooks directory to run custom scripts for automation

Configuration files store in `config/local` are ignored by git. It's a
convenient place to store local files for quick development. If you are sharing
files with a team then you may want to keep your configuration files in a
separate git repository or in shared network storage.

The only requirement to override configuration is that you need to put a file
into place at `config.local.mk`, so it is possible to copy or symlink a file
from anywhere in your system.

Examples:

```sh
ln -s config/local/my-custom-config.mk config.local.mk
make
```

```sh
ln -s /path/on/my/system/reactionconfig.mk config.local.mk
make
```

### Updating Local Branches to Match Config

If you are using the Reaction development platform for development, then you
will need to update your local branch to get the latest at some point. The
`update-checkouts` command will perform this operation.

```
make update-checkouts
```

The command is safe. It will halt if there are uncommitted changes in
git before doing anything. You may commit, stash or drop those changes.

## Breaking changes
None. Please see changes to release process.

## Changes to Release Process
This change will imply changes to the release process.

1. `config.mk` should be updated to reflect latest. We do this today, so no change here.
2. The updated `config.mk` should be copied into the `config/reaction-oss` directory. This is new.
3. It's no longer `required` to tag this repository with the Reaction version because all releases are in the config directory.
4. Changes to this repository should be checked for compatibility with the release configurations.

## Testing
```sh
# Clone the reaction-development-platform, as usual.
git clone git@github.com:reactioncommerce/reaction-development-platform.git
cd reaction-development-platform

# Download a shared config file.
curl https://gist.githubusercontent.com/ticean/00d94c82ec4bf45210d2cd2a3d41a586/raw/753edd1abf0d8ecb615fec3ce122a5f35bed8764/reaction-v3.0.4.custom.mk \
  > config/local/reaction-v3.0.4.custom.mk

# Symlink the downloaded file to `config.local.mk`.
ln -s ./config/local/reaction-v3.0.4.custom.mk config.local.mk

# Do the usual setup.
make
```