### PR TITLE
Use HTTPS instead of SSH when cloning repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Reaction Platform is a customizable, real-time, reactive commerce solution. This
 * Bourne Shell and POSIX tools (sh, grep, sed, awk, etc)
   * MacOS and Linux users will have a suitable version bundled with the OS
 * [Git][5]
-* A [GitHub][6] account with a [configured SSH key][7]
 * [Docker][0] | [Docker for Mac][1] | [Docker for Windows][2]
+* A [GitHub][6] account with a [configured SSH key][7] is not required by
+  default, but necessary when using custom, private Github repositories.
 
 ## Getting started
 

--- a/config.mk
+++ b/config.mk
@@ -27,11 +27,11 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
-git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
-git@github.com:/reactioncommerce/reaction.git,reaction,v3.4.0 \
-git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
-git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.5 \
-git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
+https://github.com/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
+https://github.com/reactioncommerce/reaction.git,reaction,v3.4.0 \
+https://github.com/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.5 \
+https://github.com/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
 endef
 
 # List of user defined networks that should be created.

--- a/config/reaction-oss/reaction-v3.0.0.mk
+++ b/config/reaction-oss/reaction-v3.0.0.mk
@@ -21,11 +21,11 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
-git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
-git@github.com:/reactioncommerce/reaction.git,reaction,v3.0.0 \
-git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
-git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.4 \
-git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
+https://github.com/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
+https://github.com/reactioncommerce/reaction.git,reaction,v3.0.0 \
+https://github.com/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.4 \
+https://github.com/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
 endef
 
 # List of user defined networks that should be created.

--- a/config/reaction-oss/reaction-v3.0.1.mk
+++ b/config/reaction-oss/reaction-v3.0.1.mk
@@ -21,11 +21,11 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
-git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
-git@github.com:/reactioncommerce/reaction.git,reaction,v3.0.0 \
-git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
-git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.5 \
-git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
+https://github.com/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
+https://github.com/reactioncommerce/reaction.git,reaction,v3.0.0 \
+https://github.com/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.5 \
+https://github.com/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
 endef
 
 # List of user defined networks that should be created.

--- a/config/reaction-oss/reaction-v3.0.2.mk
+++ b/config/reaction-oss/reaction-v3.0.2.mk
@@ -21,11 +21,11 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
-git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
-git@github.com:/reactioncommerce/reaction.git,reaction,v3.1.0 \
-git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
-git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.5 \
-git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
+https://github.com/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
+https://github.com/reactioncommerce/reaction.git,reaction,v3.1.0 \
+https://github.com/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.5 \
+https://github.com/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
 endef
 
 # List of user defined networks that should be created.

--- a/config/reaction-oss/reaction-v3.0.3.mk
+++ b/config/reaction-oss/reaction-v3.0.3.mk
@@ -21,11 +21,11 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
-git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
-git@github.com:/reactioncommerce/reaction.git,reaction,v3.1.0 \
-git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
-git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.5 \
-git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
+https://github.com/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
+https://github.com/reactioncommerce/reaction.git,reaction,v3.1.0 \
+https://github.com/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.5 \
+https://github.com/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
 endef
 
 # List of user defined networks that should be created.

--- a/config/reaction-oss/reaction-v3.0.4.mk
+++ b/config/reaction-oss/reaction-v3.0.4.mk
@@ -21,11 +21,11 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
-git@github.com:/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
-git@github.com:/reactioncommerce/reaction.git,reaction,v3.3.0 \
-git@github.com:/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
-git@github.com:/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.5 \
-git@github.com:/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
+https://github.com/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
+https://github.com/reactioncommerce/reaction.git,reaction,v3.3.0 \
+https://github.com/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.5 \
+https://github.com/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
 endef
 
 # List of user defined networks that should be created.


### PR DESCRIPTION
Resolves #119, submitted by @ilovesourcecode.

- Trigger CI
- Also updates README to note that Github SSH key is not required.