### PR TITLE
release v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.3.0
+
+This release is coordinated with the release of [Reaction v3.6.0](https://github.com/reactioncommerce/reaction/releases/tag/v3.6.0) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
+
 # v3.2.0
 
 This release is coordinated with the release of [Reaction v3.5.0](https://github.com/reactioncommerce/reaction/releases/tag/v3.5.0) and [Reaction Admin v3.0.0-beta.6](https://github.com/reactioncommerce/reaction-admin/releases/tag/v3.0.0-beta.6) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.

--- a/README.md
+++ b/README.md
@@ -254,13 +254,13 @@ The following table provides the most current version of each project used by th
 
 | Project                             | Latest release / tag                                                                                |
 |-------------------------------------|-----------------------------------------------------------------------------------------------------|
-| [reaction-development-platform][10] | [`3.0.3`](https://github.com/reactioncommerce/reaction-development-platform/tree/v3.0.3)            |
-| [reaction][10]                      | [`3.5.0`](https://github.com/reactioncommerce/reaction/tree/v3.4.0)                                 |
+| [reaction-development-platform][10] | [`3.3.0`](https://github.com/reactioncommerce/reaction-development-platform/tree/v3.3.0)            |
+| [reaction][10]                      | [`3.6.0`](https://github.com/reactioncommerce/reaction/tree/v3.6.0)                                 |
 | [reaction-hydra][12]                | [`3.0.0`](https://github.com/reactioncommerce/reaction-hydra/tree/v3.0.0)                           |
 | [reaction-identity][17]             | [`3.0.0`](https://github.com/reactioncommerce/reaction-identity/tree/v3.0.0)                        |
 | [example-storefront][13]            | [`3.0.0`](https://github.com/reactioncommerce/example-storefront/tree/v3.0.0)                       |
-| [reaction-admin (beta)][19]         | [`3.0.0-beta.6`](https://github.com/reactioncommerce/reaction-admin/tree/v3.0.0-beta.5)             |
-| [api-migrations][20]                | [`3.5.0`](https://github.com/reactioncommerce/api-migrations/tree/v3.4.0)                           |
+| [reaction-admin (beta)][19]         | [`3.0.0-beta.6`](https://github.com/reactioncommerce/reaction-admin/tree/v3.0.0-beta.6)             |
+| [api-migrations][20]                | [`3.6.0`](https://github.com/reactioncommerce/api-migrations/tree/v3.6.0)                           |
 
 ### Developer Certificate of Origin
 We use the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) in lieu of a Contributor License Agreement for all contributions to Reaction Commerce open source projects. We request that contributors agree to the terms of the DCO and indicate that agreement by signing-off all commits made to Reaction Commerce projects by adding a line with your name and email address to every Git commit message contributed:

--- a/config/reaction-oss/reaction-v3.3.0.mk
+++ b/config/reaction-oss/reaction-v3.3.0.mk
@@ -1,14 +1,8 @@
 ###############################################################################
-### Reaction Platform Configuration
+### Reaction OSS v3.3.0
 ###
-### This file defines configuration used in the Makefile.
-### You may add and/or override these values with your own custom configuration
-### in `config.local.mk`.
-###
-### Please see GNU Makes multi-line variable documentation for more info.
-### https://www.gnu.org/software/make/manual/html_node/Multi_002dLine.html
+### See: `/config.mk` for documentation.
 ###############################################################################
-
 
 # List of tools that must be installed.
 # A simple check to determine the tool is available. No version check, etc.


### PR DESCRIPTION
# v3.3.0

This release is coordinated with the release of [Reaction v3.6.0](https://github.com/reactioncommerce/reaction/releases/tag/v3.6.0) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.