### PR TITLE
feat: add clone-api-plugins command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,19 @@ $(foreach rr,$(SUBPROJECT_REPOS),$(eval $(call git-clone-template,$(shell echo $
 clone: github-configured $(foreach p,$(SUBPROJECTS),$(p))
 
 ###############################################################################
+### Git clone all API plugins
+###############################################################################
+.PHONY: clone-api-plugins
+clone-api-plugins:
+	if [ ! -d api-plugins ] ; then \
+	  mkdir api-plugins; \
+	fi; \
+	cd api-plugins; \
+	for repo in $(API_PLUGIN_REPOS); do \
+		git clone $$repo || true; \
+	done;
+
+###############################################################################
 ### Git Verify Clean
 ### Checks that the project has a clean workspace and changes won't be lost.
 ###############################################################################

--- a/README.md
+++ b/README.md
@@ -63,29 +63,29 @@ make init-example-storefront
 
 These are the available `make` commands in the `reaction-platform` root directory.
 
-| Command                                                 | Description                                                                                                                                     |
-|---------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
-| `make`                                                  | Bootstraps the entire Reaction development environment in Docker. Projects will use production Docker images and code.                          |
-| `make init-<project-name>`                              | Example: `make init-example-storefront`. Does clone/setup for a single project.                                                                 |
-| `make init-dev`                                         | Boostraps the entire Reaction development environment in Docker. Projects will use development configuration.                                   |
-| `make init-dev-<project-name>`                          | Example: `make init-dev-example-storefront`. Does clone/setup for a single project and configures it with a development configuration.          |                                                       |
-| `make stop`                                             | Stops all containers.                                                                                                                           |
-| `make stop-<project-name>`                              | Example: `make stop-example-storefront`. Stops all containers for a single project.                                                             |
-| `make start`                                            | Starts all containers.                                                                                                                          |
-| `make start-<project-name>`                             | Example: `make start-example-storefront`. Starts all containers for a single project.                                                           |
-| `make dev-<project-name>`                               | Example: `make dev-example-storefront`. Starts all containers for a single project in development mode.
-| `make dev-link`                                         | Creates `docker-compose.override.yml` symlinks for development in all projects.                                                                 |
-| `make dev-link-<project-name>`                          | Example: `make dev-link-example-storefront`. Creates development symlinks for a single project.                                                 |
-| `make dev-unlink`                                       | Removes `docker-compose.override.yml` symlinks from all projects.                                                                               |
-| `make dev-unlink-<project-name>`                        | Example: `make dev-unlink-example-storefront`. Removes the `docker-compose.override.yml` symlink for a single project.                          |                     |
-| `make rm`                                               | Removes all containers. Volumes are not removed.                                                                                                |
-| `make rm-<project-name>`                                | Example: `make rm-example-storefront`. Removes all containers for a single project. Volumes are not removed.                                    |
-| `make checkout-<project-name> <git-tag-or-branch-name>` | Example: `make checkout-example-storefront release-v3.0.0`. Does `git checkout` for a sub-project. See "Running Particular Git Branches" below. |
-| `make clean`                                            | Removes all containers, networks, and volumes. Any volume data will be lost.                                                                    |
-| `make clean-<project-name>`                             | Example: `make clean-example-storefront`. Removes all containers, networks, and volumes for a single project. Any volume data will be lost.     |
-| `make update-checkouts`                                 | Example: `make update-checkouts`. Update git checkouts on all projects. Useful for syncing dev env to config file. Safe, fails on uncommitted changes.
-| `make update-checkout-<project-name>`                   | Example: `make update-checkout-example-storefront`. Checks out branch in config file and pulls. Useful for syncing dev env to config file. Safe, fails on uncommitted changes.
-
+| Command                                                 | Description                                                                                                                                                                    |
+|---------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `make`                                                  | Bootstraps the entire Reaction development environment in Docker. Projects will use production Docker images and code.                                                         |
+| `make init-<project-name>`                              | Example: `make init-example-storefront`. Does clone/setup for a single project.                                                                                                |
+| `make init-dev`                                         | Bootstraps the entire Reaction development environment in Docker. Projects will use development configuration.                                                                 |
+| `make init-dev-<project-name>`                          | Example: `make init-dev-example-storefront`. Does clone/setup for a single project and configures it with a development configuration.                                         |
+| `make stop`                                             | Stops all containers.                                                                                                                                                          |
+| `make stop-<project-name>`                              | Example: `make stop-example-storefront`. Stops all containers for a single project.                                                                                            |
+| `make start`                                            | Starts all containers.                                                                                                                                                         |
+| `make start-<project-name>`                             | Example: `make start-example-storefront`. Starts all containers for a single project.                                                                                          |
+| `make dev-<project-name>`                               | Example: `make dev-example-storefront`. Starts all containers for a single project in development mode.                                                                        |
+| `make dev-link`                                         | Creates `docker-compose.override.yml` symlinks for development in all projects.                                                                                                |
+| `make dev-link-<project-name>`                          | Example: `make dev-link-example-storefront`. Creates development symlinks for a single project.                                                                                |
+| `make dev-unlink`                                       | Removes `docker-compose.override.yml` symlinks from all projects.                                                                                                              |
+| `make dev-unlink-<project-name>`                        | Example: `make dev-unlink-example-storefront`. Removes the `docker-compose.override.yml` symlink for a single project.                                                         |
+| `make rm`                                               | Removes all containers. Volumes are not removed.                                                                                                                               |
+| `make rm-<project-name>`                                | Example: `make rm-example-storefront`. Removes all containers for a single project. Volumes are not removed.                                                                   |
+| `make checkout-<project-name> <git-tag-or-branch-name>` | Example: `make checkout-example-storefront release-v3.0.0`. Does `git checkout` for a sub-project. See "Running Particular Git Branches" below.                                |
+| `make clean`                                            | Removes all containers, networks, and volumes. Any volume data will be lost.                                                                                                   |
+| `make clean-<project-name>`                             | Example: `make clean-example-storefront`. Removes all containers, networks, and volumes for a single project. Any volume data will be lost.                                    |
+| `make update-checkouts`                                 | Example: `make update-checkouts`. Updates git checkouts on all projects. Useful for syncing dev env to config file. Safe, fails on uncommitted changes.                        |
+| `make update-checkout-<project-name>`                   | Example: `make update-checkout-example-storefront`. Checks out branch in config file and pulls. Useful for syncing dev env to config file. Safe, fails on uncommitted changes. |
+| `make clone-api-plugins`                                | If you are going to make changes to the default plugins, this is a quick way to clone them all into an `api-plugins` subdirectory of this project.                             |
 
 ## Customizing Configuration
 
@@ -107,7 +107,6 @@ for the latest Reaction release.
 If a file named `config.local.mk` exists then it will be loaded after
 `config.mk`. Settings in `config.local.mk` will override those set in
 `config.mk`. It is ignored by source control.
-
 
 ### Running a Specific Reaction Release Version
 

--- a/config.mk
+++ b/config.mk
@@ -34,6 +34,50 @@ https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-bet
 https://github.com/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
 endef
 
+# These are all the plugins that `make clone-api-plugins` will clone.
+# `api-core` is not technically a plugin but is useful to have in the
+# same place.
+define API_PLUGIN_REPOS
+https://github.com/reactioncommerce/api-core.git \
+https://github.com/reactioncommerce/api-plugin-accounts.git \
+https://github.com/reactioncommerce/api-plugin-address-validation-test.git \
+https://github.com/reactioncommerce/api-plugin-address-validation.git \
+https://github.com/reactioncommerce/api-plugin-carts.git \
+https://github.com/reactioncommerce/api-plugin-catalogs.git \
+https://github.com/reactioncommerce/api-plugin-discounts.git \
+https://github.com/reactioncommerce/api-plugin-email-smtp.git \
+https://github.com/reactioncommerce/api-plugin-email-templates.git \
+https://github.com/reactioncommerce/api-plugin-email.git \
+https://github.com/reactioncommerce/api-plugin-files.git \
+https://github.com/reactioncommerce/api-plugin-i18n.git \
+https://github.com/reactioncommerce/api-plugin-inventory-simple.git \
+https://github.com/reactioncommerce/api-plugin-inventory.git \
+https://github.com/reactioncommerce/api-plugin-job-queue.git \
+https://github.com/reactioncommerce/api-plugin-notifications.git \
+https://github.com/reactioncommerce/api-plugin-orders.git \
+https://github.com/reactioncommerce/api-plugin-payments-stripe.git \
+https://github.com/reactioncommerce/api-plugin-payments.git \
+https://github.com/reactioncommerce/api-plugin-pricing-simple.git \
+https://github.com/reactioncommerce/api-plugin-products.git \
+https://github.com/reactioncommerce/api-plugin-settings.git \
+https://github.com/reactioncommerce/api-plugin-shipments-flat-rate.git \
+https://github.com/reactioncommerce/api-plugin-shipments.git \
+https://github.com/reactioncommerce/api-plugin-shops.git \
+https://github.com/reactioncommerce/api-plugin-simple-schema.git \
+https://github.com/reactioncommerce/api-plugin-surcharges.git \
+https://github.com/reactioncommerce/api-plugin-tags.git \
+https://github.com/reactioncommerce/api-plugin-taxes-flat-rate.git \
+https://github.com/reactioncommerce/api-plugin-taxes.git \
+https://github.com/reactioncommerce/plugin-authentication.git \
+https://github.com/reactioncommerce/plugin-discount-codes.git \
+https://github.com/reactioncommerce/plugin-navigation.git \
+https://github.com/reactioncommerce/plugin-payments-example.git \
+https://github.com/reactioncommerce/plugin-simple-authorization.git \
+https://github.com/reactioncommerce/plugin-sitemap-generator.git \
+https://github.com/reactioncommerce/plugin-system-information.git \
+https://github.com/reactioncommerce/plugin-translations.git
+endef
+
 # List of user defined networks that should be created.
 define DOCKER_NETWORKS
 reaction.localhost

--- a/config.mk
+++ b/config.mk
@@ -42,8 +42,11 @@ https://github.com/reactioncommerce/api-core.git \
 https://github.com/reactioncommerce/api-plugin-accounts.git \
 https://github.com/reactioncommerce/api-plugin-address-validation-test.git \
 https://github.com/reactioncommerce/api-plugin-address-validation.git \
+https://github.com/reactioncommerce/api-plugin-authentication.git \
+https://github.com/reactioncommerce/api-plugin-authorization-simple.git \
 https://github.com/reactioncommerce/api-plugin-carts.git \
 https://github.com/reactioncommerce/api-plugin-catalogs.git \
+https://github.com/reactioncommerce/api-plugin-discounts-codes.git \
 https://github.com/reactioncommerce/api-plugin-discounts.git \
 https://github.com/reactioncommerce/api-plugin-email-smtp.git \
 https://github.com/reactioncommerce/api-plugin-email-templates.git \
@@ -53,8 +56,10 @@ https://github.com/reactioncommerce/api-plugin-i18n.git \
 https://github.com/reactioncommerce/api-plugin-inventory-simple.git \
 https://github.com/reactioncommerce/api-plugin-inventory.git \
 https://github.com/reactioncommerce/api-plugin-job-queue.git \
+https://github.com/reactioncommerce/api-plugin-navigation.git \
 https://github.com/reactioncommerce/api-plugin-notifications.git \
 https://github.com/reactioncommerce/api-plugin-orders.git \
+https://github.com/reactioncommerce/api-plugin-payments-example.git \
 https://github.com/reactioncommerce/api-plugin-payments-stripe.git \
 https://github.com/reactioncommerce/api-plugin-payments.git \
 https://github.com/reactioncommerce/api-plugin-pricing-simple.git \
@@ -64,18 +69,13 @@ https://github.com/reactioncommerce/api-plugin-shipments-flat-rate.git \
 https://github.com/reactioncommerce/api-plugin-shipments.git \
 https://github.com/reactioncommerce/api-plugin-shops.git \
 https://github.com/reactioncommerce/api-plugin-simple-schema.git \
+https://github.com/reactioncommerce/api-plugin-sitemap-generator.git \
 https://github.com/reactioncommerce/api-plugin-surcharges.git \
+https://github.com/reactioncommerce/api-plugin-system-information.git \
 https://github.com/reactioncommerce/api-plugin-tags.git \
 https://github.com/reactioncommerce/api-plugin-taxes-flat-rate.git \
 https://github.com/reactioncommerce/api-plugin-taxes.git \
-https://github.com/reactioncommerce/plugin-authentication.git \
-https://github.com/reactioncommerce/plugin-discount-codes.git \
-https://github.com/reactioncommerce/plugin-navigation.git \
-https://github.com/reactioncommerce/plugin-payments-example.git \
-https://github.com/reactioncommerce/plugin-simple-authorization.git \
-https://github.com/reactioncommerce/plugin-sitemap-generator.git \
-https://github.com/reactioncommerce/plugin-system-information.git \
-https://github.com/reactioncommerce/plugin-translations.git
+https://github.com/reactioncommerce/api-plugin-translations.git
 endef
 
 # List of user defined networks that should be created.


### PR DESCRIPTION
Impact: **minor**  
Type: **feature**

## Changes
Adds a new command: `make clone-api-plugins`

Running this will create an `api-plugins` subfolder and `git clone` all plugin repos into it if they don't already exist.

With all code having been moved out of the main repo, it's useful to get all stock plugins into a single folder, where you can do code searches across all plugins, easily update them and link them in, etc. This is a simple way to support that.

## Breaking changes
None

## Testing
1. Run `make clone-api-plugins`
2. Verify that all stock plugins are cloned into an `api-plugins` subfolder, all of which should be gitignored by this repo.