### PR TITLE
release 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.4.0
+
+This release is coordinated with the release of [Reaction v3.7.0](https://github.com/reactioncommerce/reaction/releases/tag/v3.7.0) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
+
 # v3.3.0
 
 This release is coordinated with the release of [Reaction v3.6.0](https://github.com/reactioncommerce/reaction/releases/tag/v3.6.0) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.

--- a/README.md
+++ b/README.md
@@ -254,12 +254,12 @@ The following table provides the most current version of each project used by th
 | Project                             | Latest release / tag                                                                                |
 |-------------------------------------|-----------------------------------------------------------------------------------------------------|
 | [reaction-development-platform][10] | [`3.3.0`](https://github.com/reactioncommerce/reaction-development-platform/tree/v3.3.0)            |
-| [reaction][10]                      | [`3.6.0`](https://github.com/reactioncommerce/reaction/tree/v3.6.0)                                 |
+| [reaction][10]                      | [`3.7.0`](https://github.com/reactioncommerce/reaction/tree/v3.7.0)                                 |
 | [reaction-hydra][12]                | [`3.0.0`](https://github.com/reactioncommerce/reaction-hydra/tree/v3.0.0)                           |
 | [reaction-identity][17]             | [`3.0.0`](https://github.com/reactioncommerce/reaction-identity/tree/v3.0.0)                        |
 | [example-storefront][13]            | [`3.0.0`](https://github.com/reactioncommerce/example-storefront/tree/v3.0.0)                       |
 | [reaction-admin (beta)][19]         | [`3.0.0-beta.6`](https://github.com/reactioncommerce/reaction-admin/tree/v3.0.0-beta.6)             |
-| [api-migrations][20]                | [`3.6.0`](https://github.com/reactioncommerce/api-migrations/tree/v3.6.0)                           |
+| [api-migrations][20]                | [`3.7.0`](https://github.com/reactioncommerce/api-migrations/tree/v3.7.0)                           |
 
 ### Developer Certificate of Origin
 We use the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) in lieu of a Contributor License Agreement for all contributions to Reaction Commerce open source projects. We request that contributors agree to the terms of the DCO and indicate that agreement by signing-off all commits made to Reaction Commerce projects by adding a line with your name and email address to every Git commit message contributed:

--- a/config.mk
+++ b/config.mk
@@ -28,7 +28,7 @@ endef
 # Projects will be started in this order
 define SUBPROJECT_REPOS
 https://github.com/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
-https://github.com/reactioncommerce/reaction.git,reaction,v3.6.0 \
+https://github.com/reactioncommerce/reaction.git,reaction,v3.7.0 \
 https://github.com/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
 https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.6 \
 https://github.com/reactioncommerce/example-storefront.git,example-storefront,v3.0.0

--- a/config/reaction-oss/reaction-v3.4.0.mk
+++ b/config/reaction-oss/reaction-v3.4.0.mk
@@ -1,0 +1,34 @@
+###############################################################################
+### Reaction OSS v3.4.0
+###
+### See: `/config.mk` for documentation.
+###############################################################################
+
+# List of tools that must be installed.
+# A simple check to determine the tool is available. No version check, etc.
+define REQUIRED_SOFTWARE
+docker \
+docker-compose \
+git \
+node \
+yarn
+endef
+
+# Defined here are the subprojects in a comma-separated format
+# GIT_REPO_URL,SUBDIR_NAME,TAG
+# GIT_REPO_URL is the URL of the git repository
+# SUBDIR_NAME is just the directory name itself
+# TAG is the git tag or branch to checkout
+# Projects will be started in this order
+define SUBPROJECT_REPOS
+https://github.com/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
+https://github.com/reactioncommerce/reaction.git,reaction,v3.7.0 \
+https://github.com/reactioncommerce/reaction-identity.git,reaction-identity,v3.0.0 \
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.6 \
+https://github.com/reactioncommerce/example-storefront.git,example-storefront,v3.0.0
+endef
+
+# List of user defined networks that should be created.
+define DOCKER_NETWORKS
+reaction.localhost
+endef


### PR DESCRIPTION
# v3.4.0

This release is coordinated with the release of [Reaction v3.7.0](https://github.com/reactioncommerce/reaction/releases/tag/v3.7.0) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.