### PR TITLE
revert: removing hydra and identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ Behind the scenes `make` is
 
 These services will be running when the initial `make` command is complete:
 
-| Service                                          | Description                                                                                                                                                                                    |
-| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Reaction API][10] (http://localhost:3000)       | The Reaction API, which includes [a GraphQL endpoint](http://localhost:3000/graphql). See [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/features/graphql-playground/). |
-| [Reaction Admin][19] (http://localhost:4080)     | A user interface for administrators and shop managers to configure shops, manage products, and process orders.                                                                                 |
-| [Example Storefront][13] (http://localhost:4000) | An example Reaction storefront UI built with [Next.JS](https://github.com/zeit/next.js/).                                                                                                      |
+| Service                                             | Description                                                                                                                                                                                    |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [OAuth2 Server (Hydra)][12] (http://localhost:4444) | [ORY Hydra][11] OAuth2 token server.                                                                                                                                                           |
+| [Reaction Identity][17] (http://localhost:4100)     | The OAuth2-compatible user interface for Reaction Identity, such as login and registration.                                                                                                    |
+| [Reaction API][10] (http://localhost:3000)          | The Reaction API, which includes [a GraphQL endpoint](http://localhost:3000/graphql). See [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/features/graphql-playground/). |
+| [Reaction Admin][19] (http://localhost:4080)        | A user interface for administrators and shop managers to configure shops, manage products, and process orders.                                                                                 |
+| [Example Storefront][13] (http://localhost:4000)    | An example Reaction storefront UI built with [Next.JS](https://github.com/zeit/next.js/).                                                                                                      |
 
 If the `make` command fails at some point, you can run or rerun it for specific services with:
 
@@ -235,11 +237,13 @@ When you need to communicate with one service from another over the internal Doc
 
 You may refer to each sub-project's README for additional operation details.
 
-| Sub-project                | Description        | Documentation                    |
-| -------------------------- | ------------------ | -------------------------------- |
-| [`reaction`][10]           | GraphQL API        | [Reaction API Documentation][14] |
-| [`reaction-admin`][19]     | Classic Admin UI   | [Reaction Admin Readme][20]      |
-| [`example-storefront`][13] | Example Storefront | [Example Storefront docs][15]    |
+| Sub-project                | Description           | Documentation                                     |
+| -------------------------- | --------------------- | ------------------------------------------------- |
+| [`reaction`][10]           | GraphQL API           | [Reaction API Documentation][14]                  |
+| [`reaction-hydra`][12]     | Authentication server | [Reaction Hydra Readme][16], [Ory Hydra docs][11] |
+| [`reaction-identity`][17]  | Identity service      | [Reaction Identity Readme][18]                    |
+| [`reaction-admin`][19]     | Classic Admin UI      | [Reaction Admin Readme][20]                       |
+| [`example-storefront`][13] | Example Storefront    | [Example Storefront docs][15]                     |
 
 For tips on developing with Docker, read our [Docker docs](https://docs.reactioncommerce.com/docs/installation-docker-development).
 
@@ -251,6 +255,8 @@ The following table provides the most current version of each project used by th
 | ----------------------------------- | ------------------------------------------------------------------------------------------ |
 | [reaction-development-platform][10] | [`3.12.0`](https://github.com/reactioncommerce/reaction-development-platform/tree/v3.12.0) |
 | [reaction][10]                      | [`3.11.1`](https://github.com/reactioncommerce/reaction/tree/v3.11.1)                      |
+| [reaction-hydra][12]                | [`3.0.0`](https://github.com/reactioncommerce/reaction-hydra/tree/v3.0.0)                  |
+| [reaction-identity][17]             | [`3.3.0`](https://github.com/reactioncommerce/reaction-identity/tree/v3.3.0)               |
 | [example-storefront][13]            | [`4.0.2`](https://github.com/reactioncommerce/example-storefront/tree/v4.0.2)              |
 | [reaction-admin (beta)][19]         | [`3.0.0-beta.13`](https://github.com/reactioncommerce/reaction-admin/tree/v3.0.0-beta.13)  |
 | [api-migrations][20]                | [`3.11.0`](https://github.com/reactioncommerce/api-migrations/tree/v3.11.0)                |
@@ -284,9 +290,14 @@ Copyright © [GNU General Public License v3.0](./LICENSE.md)
 [8]: https://github.com/reactioncommerce/reaction-platform "Reaction Platform"
 [9]: https://github.com/graphcool/graphql-playground "GraphQL Playground"
 [10]: https://github.com/reactioncommerce/reaction "Reaction API"
+[11]: https://github.com/ory/hydra "ORY Hydra"
+[12]: https://github.com/reactioncommerce/reaction-hydra "Reaction Hydra"
 [13]: https://github.com/reactioncommerce/example-storefront "Example Storefront"
 [14]: https://docs.reactioncommerce.com "Reaction Documentation"
 [15]: https://github.com/reactioncommerce/example-storefront/tree/master/docs "Example Storefront docs"
+[16]: https://github.com/reactioncommerce/reaction-hydra/blob/master/README.md "Reaction Hydra Readme"
+[17]: https://github.com/reactioncommerce/reaction-identity "Reaction Identity"
+[18]: https://github.com/reactioncommerce/reaction-identity/blob/trunk/README.md "Reaction Identity Readme"
 [19]: https://github.com/reactioncommerce/reaction-admin "Reaction Admin"
 [20]: https://github.com/reactioncommerce/reaction-admin/blob/trunk/README.md "Reaction Admin Readme"
 [20]: https://github.com/reactioncommerce/api-migrations "API Migrations"

--- a/config.mk
+++ b/config.mk
@@ -27,8 +27,10 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
+https://github.com/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
 https://github.com/reactioncommerce/reaction.git,reaction,v3.11.1 \
 https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.13 \
+https://github.com/reactioncommerce/reaction-identity.git,reaction-identity,v3.3.0 \
 https://github.com/reactioncommerce/example-storefront.git,example-storefront,v4.0.2
 endef
 


### PR DESCRIPTION
Resolves #175 
Impact: **critical**  
Type: **bugfix**

## Issue
PR for removing Identity and Hydra was merged, because of which anyone cloning the project was getting errors about Hydra not being found. This was happening because reaction-admin was still using Hydra.

## Solution
Till we are able to release other repos, this commit should be reversed. Once the other repos are released, we can update the code to remove Hydra/Identity and point to the correct version of sub-repos to fetch.

## Testing
1. Pull the code.
2. Make sure you are able to run `make` in a clean repo.
3. Do `docker ps` and all the services(including hydra and identity) should be running.
4. Make sure login works on example-storefront/admin.
