### PR TITLE
Release v3.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v3.13.0
+This release is coordinated with the release of [reaction-admin v3.0.0-beta.15](https://github.com/reactioncommerce/reaction-admin/releases/tag/v3.0.0-beta.15), [reaction v3.13.0](https://github.com/reactioncommerce/reaction/releases/tag/v3.13.0), [example-storefront v4.0.2](https://github.com/reactioncommerce/example-storefront/releases/tag/v4.0.2) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
 # v3.12.0
 This release is coordinated with the release of [reaction-admin v3.0.0-beta.13(https://github.com/reactioncommerce/reaction-admin/releases/tag/v3.0.0-beta.13)], [example-storefront v4.0.2(https://github.com/reactioncommerce/example-storefront/releases/tag/v4.0.2)], [reaction-identity v3.3.1(https://github.com/reactioncommerce/reaction-identity/releases/tag/v3.3.1)] to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
 # v3.11.1

--- a/README.md
+++ b/README.md
@@ -253,12 +253,12 @@ The following table provides the most current version of each project used by th
 
 | Project                             | Latest release / tag                                                                       |
 | ----------------------------------- | ------------------------------------------------------------------------------------------ |
-| [reaction-development-platform][10] | [`3.12.0`](https://github.com/reactioncommerce/reaction-development-platform/tree/v3.12.0) |
-| [reaction][10]                      | [`3.11.1`](https://github.com/reactioncommerce/reaction/tree/v3.11.1)                      |
+| [reaction-development-platform][10] | [`3.13.0`](https://github.com/reactioncommerce/reaction-development-platform/tree/v3.13.0) |
+| [reaction][10]                      | [`3.13.0`](https://github.com/reactioncommerce/reaction/tree/v3.13.0)                      |
 | [reaction-hydra][12]                | [`3.0.0`](https://github.com/reactioncommerce/reaction-hydra/tree/v3.0.0)                  |
 | [reaction-identity][17]             | [`3.3.0`](https://github.com/reactioncommerce/reaction-identity/tree/v3.3.0)               |
 | [example-storefront][13]            | [`4.0.2`](https://github.com/reactioncommerce/example-storefront/tree/v4.0.2)              |
-| [reaction-admin (beta)][19]         | [`3.0.0-beta.13`](https://github.com/reactioncommerce/reaction-admin/tree/v3.0.0-beta.13)  |
+| [reaction-admin (beta)][19]         | [`3.0.0-beta.15`](https://github.com/reactioncommerce/reaction-admin/tree/v3.0.0-beta.15)  |
 | [api-migrations][20]                | [`3.11.0`](https://github.com/reactioncommerce/api-migrations/tree/v3.11.0)                |
 
 ### Developer Certificate of Origin

--- a/config.mk
+++ b/config.mk
@@ -28,8 +28,8 @@ endef
 # Projects will be started in this order
 define SUBPROJECT_REPOS
 https://github.com/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
-https://github.com/reactioncommerce/reaction.git,reaction,v3.11.1 \
-https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.13 \
+https://github.com/reactioncommerce/reaction.git,reaction,v3.13.0 \
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.15 \
 https://github.com/reactioncommerce/reaction-identity.git,reaction-identity,v3.3.0 \
 https://github.com/reactioncommerce/example-storefront.git,example-storefront,v4.0.2
 endef

--- a/config/reaction-oss/reaction-v3.13.0.mk
+++ b/config/reaction-oss/reaction-v3.13.0.mk
@@ -1,0 +1,34 @@
+###############################################################################
+### Reaction OSS v3.11.1
+###
+### See: `/config.mk` for documentation.
+###############################################################################
+
+# List of tools that must be installed.
+# A simple check to determine the tool is available. No version check, etc.
+define REQUIRED_SOFTWARE
+docker \
+docker-compose \
+git \
+node \
+yarn
+endef
+
+# Defined here are the subprojects in a comma-separated format
+# GIT_REPO_URL,SUBDIR_NAME,TAG
+# GIT_REPO_URL is the URL of the git repository
+# SUBDIR_NAME is just the directory name itself
+# TAG is the git tag or branch to checkout
+# Projects will be started in this order
+define SUBPROJECT_REPOS
+https://github.com/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
+https://github.com/reactioncommerce/reaction.git,reaction,v3.13.0 \
+https://github.com/reactioncommerce/reaction-identity.git,reaction-identity,v3.3.1 \
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.15 \
+https://github.com/reactioncommerce/example-storefront.git,example-storefront,v4.0.2
+endef
+
+# List of user defined networks that should be created.
+define DOCKER_NETWORKS
+reaction.localhost
+endef


### PR DESCRIPTION
# v3.13.0
This release is coordinated with the release of [reaction-admin v3.0.0-beta.15](https://github.com/reactioncommerce/reaction-admin/releases/tag/v3.0.0-beta.15), [reaction v3.13.0](https://github.com/reactioncommerce/reaction/releases/tag/v3.13.0), [example-storefront v4.0.2](https://github.com/reactioncommerce/example-storefront/releases/tag/v4.0.2) to keep the  up-to-date with the latest version of all our development platform projects.
