### PR TITLE
Use a reaction-admin version that is not broken

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -29,7 +29,7 @@ endef
 define SUBPROJECT_REPOS
 https://github.com/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
 https://github.com/reactioncommerce/reaction.git,reaction,v3.13.2 \
-https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.19 \
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.21 \
 https://github.com/reactioncommerce/reaction-identity.git,reaction-identity,v3.3.1 \
 https://github.com/reactioncommerce/example-storefront.git,example-storefront,v4.1.0
 endef


### PR DESCRIPTION

Impact: major
Type: bugfix

## Issue
After following all the [instructions](https://mailchimp.com/developer/open-commerce/guides/quick-start/#clone-and-start-the-platform) for a fresh installation, the Navigation section of the admin panel is broken. The page goes totally blank. Tested in both linux and windows. 

## Solution
After I switched to reaction-admin,v3.0.0-beta.21, the issue was gone.

