### PR TITLE
fix: remove extra comma from config

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -29,7 +29,7 @@ endef
 define SUBPROJECT_REPOS
 
 https://github.com/reactioncommerce/reaction.git,reaction,v3.13.4 \
-https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,,v3.0.0-beta.22 \
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.22 \
 https://github.com/reactioncommerce/example-storefront.git,example-storefront,v4.1.2
 
 endef


### PR DESCRIPTION
This PR fixed the issue of having a extra comma in the `config.mk` file