### PR TITLE
fix: version bump calculated correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Example:
 make init-example-storefront
 ```
 
+## Migrating from v3.x.x to v4.x.x
+
+Look at the detailed guide [here](docs/migration-guide-v4.md)
+
 ## Project Commands
 
 These are the available `make` commands in the `reaction-platform` root directory.

--- a/release.py
+++ b/release.py
@@ -58,9 +58,14 @@ def line_prepender(filename, line):
         f.write(line + content)
 
 def getBump(commits):
+    level = 'patch'
     for author, commit, pullNumber in commits:
         if commit.lower().startswith('feat'):
-            return 'minor'
+            ## its minor if not already major
+            if level != 'major':
+                level = 'minor'
+        if 'BREAKING CHANGE:' in commit:
+            return 'major'
     return 'patch'
 
 def getVersion(prevVersion, commits):
@@ -71,6 +76,8 @@ def getVersion(prevVersion, commits):
         bump = getBump(commits)
         if bump == 'minor':
             nextVersion = prevVersion.next_minor()
+        elif bump == 'major':
+            nextVersion = prevVersion.next_major()
         else:
             nextVersion = prevVersion.next_patch()
     return str(nextVersion)


### PR DESCRIPTION
This PR fixes the release script to handle major version changes. It also adds a link to the migration guide.