### PR TITLE
Release v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v4.0.0
+This release is coordinated with the release of [reaction-admin v4.0.0-beta.3](https://github.com/reactioncommerce/reaction-admin/releases/tag/v4.0.0-beta.3), [reaction v4.0.0](https://github.com/reactioncommerce/reaction/releases/tag/v4.0.0), [example-storefront v5.0.0](https://github.com/reactioncommerce/example-storefront/releases/tag/v5.0.0) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
 # v3.14.2
 This release is coordinated with the release of [reaction-admin v3.0.0-beta.22](https://github.com/reactioncommerce/reaction-admin/releases/tag/v3.0.0-beta.22), [reaction v3.13.4](https://github.com/reactioncommerce/reaction/releases/tag/v3.13.4), [example-storefront v4.1.2](https://github.com/reactioncommerce/example-storefront/releases/tag/v4.1.2), [reaction-identity v3.3.1](https://github.com/reactioncommerce/reaction-identity/releases/tag/v3.3.1) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
 # v3.14.1

--- a/config.mk
+++ b/config.mk
@@ -28,9 +28,9 @@ endef
 # Projects will be started in this order
 define SUBPROJECT_REPOS
 
-https://github.com/reactioncommerce/reaction.git,reaction,v3.13.4 \
-https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.22 \
-https://github.com/reactioncommerce/example-storefront.git,example-storefront,v4.1.2
+https://github.com/reactioncommerce/reaction.git,reaction,v4.0.0 \
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v4.0.0-beta.3 \
+https://github.com/reactioncommerce/example-storefront.git,example-storefront,v5.0.0
 
 endef
 

--- a/config/reaction-oss/reaction-v4.0.0.mk
+++ b/config/reaction-oss/reaction-v4.0.0.mk
@@ -1,0 +1,34 @@
+###############################################################################
+### Reaction OSS v4.0.0
+###
+### See: `/config.mk` for documentation.
+###############################################################################
+
+# List of tools that must be installed.
+# A simple check to determine the tool is available. No version check, etc.
+define REQUIRED_SOFTWARE
+docker \
+docker-compose \
+git \
+node \
+yarn
+endef
+
+# Defined here are the subprojects in a comma-separated format
+# GIT_REPO_URL,SUBDIR_NAME,TAG
+# GIT_REPO_URL is the URL of the git repository
+# SUBDIR_NAME is just the directory name itself
+# TAG is the git tag or branch to checkout
+# Projects will be started in this order
+define SUBPROJECT_REPOS
+https://github.com/reactioncommerce/reaction-hydra.git,reaction-hydra,v3.0.0 \
+https://github.com/reactioncommerce/reaction.git,reaction,v3.13.2 \
+https://github.com/reactioncommerce/reaction-identity.git,reaction-identity,v3.3.1 \
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v3.0.0-beta.19 \
+https://github.com/reactioncommerce/example-storefront.git,example-storefront,v4.1.0
+endef
+
+# List of user defined networks that should be created.
+define DOCKER_NETWORKS
+reaction.localhost
+endef


### PR DESCRIPTION
# v4.0.0
This release is coordinated with the release of [reaction-admin v4.0.0-beta.3](https://github.com/reactioncommerce/reaction-admin/releases/tag/v4.0.0-beta.3), [reaction v4.0.0](https://github.com/reactioncommerce/reaction/releases/tag/v4.0.0), [example-storefront v5.0.0](https://github.com/reactioncommerce/example-storefront/releases/tag/v5.0.0) to keep the  up-to-date with the latest version of all our development platform projects.
