### PR TITLE
Release v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v4.0.1
+This release is coordinated with the release of [reaction-admin v4.0.0-beta.4](https://github.com/reactioncommerce/reaction-admin/releases/tag/v4.0.0-beta.4), [reaction v4.0.0](https://github.com/reactioncommerce/reaction/releases/tag/v4.0.0), [example-storefront v5.0.3](https://github.com/reactioncommerce/example-storefront/releases/tag/v5.0.3) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
 # v4.0.0
 This release is coordinated with the release of [reaction-admin v4.0.0-beta.3](https://github.com/reactioncommerce/reaction-admin/releases/tag/v4.0.0-beta.3), [reaction v4.0.0](https://github.com/reactioncommerce/reaction/releases/tag/v4.0.0), [example-storefront v5.0.0](https://github.com/reactioncommerce/example-storefront/releases/tag/v5.0.0) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
 # v3.14.2

--- a/README.md
+++ b/README.md
@@ -257,10 +257,10 @@ The following table provides the most current version of each project used by th
 
 | Project                             | Latest release / tag                                                                     |
 | ----------------------------------- | ---------------------------------------------------------------------------------------- |
-| [reaction-development-platform][10] | [`4.0.0`](https://github.com/reactioncommerce/reaction-development-platform/tree/v4.0.0) |
+| [reaction-development-platform][10] | [`4.0.1`](https://github.com/reactioncommerce/reaction-development-platform/tree/v4.0.1) |
 | [reaction][10]                      | [`4.0.0`](https://github.com/reactioncommerce/reaction/tree/v4.0.0)                      |
-| [example-storefront][13]            | [`5.0.0`](https://github.com/reactioncommerce/example-storefront/tree/v5.0.0)            |
-| [reaction-admin (beta)][19]         | [`4.0.0-beta.3`](https://github.com/reactioncommerce/reaction-admin/tree/v4.0.0-beta.3)  |
+| [example-storefront][13]            | [`5.0.3`](https://github.com/reactioncommerce/example-storefront/tree/v5.0.3)            |
+| [reaction-admin (beta)][19]         | [`4.0.0-beta.4`](https://github.com/reactioncommerce/reaction-admin/tree/v4.0.0-beta.4)  |
 
 ### [Release Process](docs/release-guide.md)
 

--- a/config.mk
+++ b/config.mk
@@ -29,8 +29,8 @@ endef
 define SUBPROJECT_REPOS
 
 https://github.com/reactioncommerce/reaction.git,reaction,v4.0.0 \
-https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v4.0.0-beta.3 \
-https://github.com/reactioncommerce/example-storefront.git,example-storefront,v5.0.0
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v4.0.0-beta.4 \
+https://github.com/reactioncommerce/example-storefront.git,example-storefront,v5.0.3
 
 endef
 

--- a/config/reaction-oss/reaction-v4.0.1.mk
+++ b/config/reaction-oss/reaction-v4.0.1.mk
@@ -1,0 +1,32 @@
+###############################################################################
+### Reaction OSS v4.0.1
+###
+### See: `/config.mk` for documentation.
+###############################################################################
+
+# List of tools that must be installed.
+# A simple check to determine the tool is available. No version check, etc.
+define REQUIRED_SOFTWARE
+docker \
+docker-compose \
+git \
+node \
+yarn
+endef
+
+# Defined here are the subprojects in a comma-separated format
+# GIT_REPO_URL,SUBDIR_NAME,TAG
+# GIT_REPO_URL is the URL of the git repository
+# SUBDIR_NAME is just the directory name itself
+# TAG is the git tag or branch to checkout
+# Projects will be started in this order
+define SUBPROJECT_REPOS
+https://github.com/reactioncommerce/reaction.git,reaction,v4.0.0 \
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v4.0.0-beta.4 \
+https://github.com/reactioncommerce/example-storefront.git,example-storefront,v5.0.3
+endef
+
+# List of user defined networks that should be created.
+define DOCKER_NETWORKS
+reaction.localhost
+endef


### PR DESCRIPTION
# v4.0.1
This release is coordinated with the release of [reaction-admin v4.0.0-beta.4](https://github.com/reactioncommerce/reaction-admin/releases/tag/v4.0.0-beta.4), [reaction v4.0.0](https://github.com/reactioncommerce/reaction/releases/tag/v4.0.0), [example-storefront v5.0.3](https://github.com/reactioncommerce/example-storefront/releases/tag/v5.0.3) to keep the  up-to-date with the latest version of all our development platform projects.
