### PR TITLE
feat: release 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v4.1.0
+This release is coordinated with the release of [reaction-admin v4.0.0-beta.20](https://github.com/reactioncommerce/reaction-admin/releases/tag/v4.0.0-beta.20), [reaction v4.2.0](https://github.com/reactioncommerce/reaction/releases/tag/v4.2.0), [example-storefront v5.2.1](https://github.com/reactioncommerce/example-storefront/releases/tag/v5.2.1) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
 # v4.0.1
 This release is coordinated with the release of [reaction-admin v4.0.0-beta.5](https://github.com/reactioncommerce/reaction-admin/releases/tag/v4.0.0-beta.5), [reaction v4.0.0](https://github.com/reactioncommerce/reaction/releases/tag/v4.0.0), [example-storefront v5.0.3](https://github.com/reactioncommerce/example-storefront/releases/tag/v5.0.3) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.
 # v4.0.0

--- a/config.mk
+++ b/config.mk
@@ -27,9 +27,9 @@ endef
 # TAG is the git tag or branch to checkout
 # Projects will be started in this order
 define SUBPROJECT_REPOS
-https://github.com/reactioncommerce/reaction.git,reaction,v4.1.5 \
-https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v4.0.0-beta.13 \
-https://github.com/reactioncommerce/example-storefront.git,example-storefront,v5.1.1
+https://github.com/reactioncommerce/reaction.git,reaction,v4.2.0 \
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v4.0.0-beta.20 \
+https://github.com/reactioncommerce/example-storefront.git,example-storefront,v5.2.1
 endef
 
 # These are all the plugins that `make clone-api-plugins` will clone.

--- a/config/reaction-oss/reaction-v4.1.0.mk
+++ b/config/reaction-oss/reaction-v4.1.0.mk
@@ -1,0 +1,32 @@
+###############################################################################
+### Reaction OSS v4.1.0
+###
+### See: `/config.mk` for documentation.
+###############################################################################
+
+# List of tools that must be installed.
+# A simple check to determine the tool is available. No version check, etc.
+define REQUIRED_SOFTWARE
+docker \
+docker-compose \
+git \
+node \
+yarn
+endef
+
+# Defined here are the subprojects in a comma-separated format
+# GIT_REPO_URL,SUBDIR_NAME,TAG
+# GIT_REPO_URL is the URL of the git repository
+# SUBDIR_NAME is just the directory name itself
+# TAG is the git tag or branch to checkout
+# Projects will be started in this order
+define SUBPROJECT_REPOS
+https://github.com/reactioncommerce/reaction.git,reaction,v4.2.0 \
+https://github.com/reactioncommerce/reaction-admin.git,reaction-admin,v4.0.0-beta.20 \
+https://github.com/reactioncommerce/example-storefront.git,example-storefront,v5.2.1
+endef
+
+# List of user defined networks that should be created.
+define DOCKER_NETWORKS
+reaction.localhost
+endef


### PR DESCRIPTION
Signed-off-by: Brent Hoover <brent@thebuddhalodge.com>

# v4.1.0
This release is coordinated with the release of [reaction-admin v4.0.0-beta.20](https://github.com/reactioncommerce/reaction-admin/releases/tag/v4.0.0-beta.20), [reaction v4.2.0](https://github.com/reactioncommerce/reaction/releases/tag/v4.2.0), [example-storefront v5.2.1](https://github.com/reactioncommerce/example-storefront/releases/tag/v5.2.1) to keep the `reaction-development-platform` up-to-date with the latest version of all our development platform projects.

